### PR TITLE
Fix CONNECT for large MQTT payloads

### DIFF
--- a/adafruit_minimqtt.py
+++ b/adafruit_minimqtt.py
@@ -64,7 +64,7 @@ MQTT_PINGRESP = const(0xd0)
 MQTT_SUB = b'\x82'
 MQTT_UNSUB = b'\xA2'
 MQTT_PUB = bytearray(b'\x30\0')
-MQTT_CON = bytearray(b'\x10\0\0')
+MQTT_CON = bytearray(b"\x10\x00\x00\x00")
 # Variable CONNECT header [MQTT 3.1.2]
 MQTT_CON_HEADER = bytearray(b"\x04MQTT\x04\x02\0\0")
 MQTT_DISCONNECT = b'\xe0\0'
@@ -138,7 +138,7 @@ class MQTT:
         self._is_connected = False
         self._msg_size_lim = MQTT_MSG_SZ_LIM
         self.packet_id = 0
-        self._keep_alive = 0
+        self._keep_alive = 60
         self._pid = 0
         self._user_data = None
         self._subscribed_topics = []

--- a/adafruit_minimqtt.py
+++ b/adafruit_minimqtt.py
@@ -275,7 +275,8 @@ class MQTT:
         if large_rel_length:
             fixed_header.append(0x00)
         else:
-            fixed_header.append(remaining_length + 0x00)
+            fixed_header.append(remaining_length)
+            fixed_header.append(0x00)
 
         if self._logger is not None:
             self._logger.debug('Sending CONNECT to broker')


### PR DESCRIPTION
The _remaining length_  used by `connect` is incompatible with large payloads (>127 bytes). An instance of this is when a long (> 300 byte) password, such as a JSON Web Token, or a long client identifier is provided.

* The remaining length calculation used by this library has been removed in favor of using the  algorithm described by the MQTT V3.1.1 specification (https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718030).
* Default `keepalive` value sent by `connect()` increased to 60 seconds to ensure the MQTT broker rejects incorrect connections, instead of hanging `_wait_for_msg()`.
* Fixed header bytearray removed, switching to a variable bytearray.
* Variables within `connect` renamed to correct names per the MQTT spec.


Tested with a PyPortal running CircuitPython Latest, two tests were run to verify compatibility with existing (small) payloads and large connect payloads...

[MiniMQTT Example - Adafruit IO WiFi](https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/blob/master/examples/minimqtt_adafruitio_wifi.py) - testing small (<127 byte) connect payload.
```
Connecting to Adafruit IO...
25346.9: DEBUG - Creating new socket
25347.0: DEBUG - Attempting to establish secure MQTT connection...
appemnding...
25349.8: DEBUG - Sending CONNECT to broker
25349.9: DEBUG - Fixed Header: bytearray(b'\x10>\x00')
Variable Header: bytearray(b'\x04MQTT\x04\xc2\x00<')
25350.2: DEBUG - Receiving CONNACK packet from broker
Connected to Adafruit IO! Listening for topic changes on brubell/feeds/onoff
```

Connecting to Google's Cloud IoT MQTT Server - testing large (512B+) connect payload.
```
Attempting to connect to mqtt.googleapis.com
25400.9: DEBUG - Creating new socket
25400.9: DEBUG - Attempting to establish secure MQTT connection...
25403.5: DEBUG - Sending CONNECT to broker
25403.5: DEBUG - Fixed Header: bytearray(b'\x10\xb6\x04\x00')
Variable Header: bytearray(b'\x04MQTT\x04\xc2\x00<')
25403.8: DEBUG - Receiving CONNACK packet from broker
Connected to MQTT Broker!
Flags: 0
 RC: 0
```