### PR TITLE
Improve network handling and implement time-based KeepAlive

### DIFF
--- a/adafruit_minimqtt.py
+++ b/adafruit_minimqtt.py
@@ -90,8 +90,7 @@ class MQTT:
     :param str client_id: Optional client identifier, defaults to a unique, generated string.
     :param bool is_ssl: Sets a secure or insecure connection with the broker.
     :param bool log: Attaches a logger to the MQTT client, defaults to logging level INFO.
-    :param int keep_alive: KeepAlive interval between the broker and the
-                            MiniMQTT client, in seconds.
+    :param int keep_alive: KeepAlive interval between the broker and the MiniMQTT client.
     """
     # pylint: disable=too-many-arguments,too-many-instance-attributes, not-callable, invalid-name, no-member
     def __init__(self, socket, broker, port=None, username=None,


### PR DESCRIPTION
This pull request improves how the library handles the MQTT KeepAlive with the initial CONNECT packet [MQTT-3.1.2-23]. We'll connect to a server, and _stay_ connected.

* `keep_alive` exposed as an init kwarg - different brokers expect different `keeep_alive` values and a user may also want to set this value manually.
* The `loop` method now checks the time and sends a PINGREQ (expecting a PINGRESP, this is handled in the `ping()` method) to the server if the time elapsed is greater than or equal to the provided keepalive value. 
* The `loop_forever` method has been refactored to call `loop` instead of `_wait_for_msg`. This method also now handles network control, for both the socket and the NetworkManager (currently WiFiManager) objects. 
  * Properties for network management (`is_wifi_connected`, `is_sock_connected`) have been added as well as additional management for both the socket and ESP32SPI wifi module (`reconnect_socket`, `reconnect_wifi`)


Before this patch was applied:
![image](https://user-images.githubusercontent.com/322428/63063495-f2f00c00-beca-11e9-832e-3374d3c63f80.png)


After:
![image](https://user-images.githubusercontent.com/322428/63063503-f8e5ed00-beca-11e9-93b6-b5816a621ff9.png)
