### PR TITLE
Fix CONNACK IndexError 

### DIFF
--- a/adafruit_minimqtt.py
+++ b/adafruit_minimqtt.py
@@ -279,7 +279,7 @@ class MQTT:
                 rc = self._sock.read(3)
                 assert rc[0] == 0x02
                 if rc[2] != 0x00:
-                    raise MMQTTException(CONNACK_ERRORS[rc[3]])
+                    raise MMQTTException(CONNACK_ERRORS[rc[2]])
                 self._is_connected = True
                 result = rc[0] & 1
                 if self.on_connect is not None:


### PR DESCRIPTION
`rc` reads 3 bytes, not 4. The 3rd byte is the error code, referenced by `CONNACK_ERRORS`

Pre-PR:
```
b'\x02\x00\x05'
Traceback (most recent call last):
  File "code.py", line 121, in <module>
  File "/lib/adafruit_iotcore/adafruit_iotcore.py", line 121, in connect
  File "/lib/adafruit_minimqtt.py", line 284, in connect
IndexError: bytes index out of range
```

Post-PR:
```
4132.02: DEBUG - Receiving CONNACK packet from broker
b'\x02\x00\x05'
Traceback (most recent call last):
  File "code.py", line 121, in <module>
  File "/lib/adafruit_iotcore/adafruit_iotcore.py", line 121, in connect
  File "/lib/adafruit_minimqtt.py", line 284, in connect
MMQTTException: Connection Refused - Unauthorized
```