### PR TITLE
Add example for using MiniMQTT with User-Provided Certificate/Key

### DIFF
--- a/examples/minimqtt_certificate.py
+++ b/examples/minimqtt_certificate.py
@@ -87,10 +87,10 @@ except ImportError:
     raise
 
 # Set Device Certificate
-esp.set_certificate(CERT)
+esp.set_certificate(DEVICE_CERT)
 
 # Set Private Key
-esp.set_private_key(KEY)
+esp.set_private_key(DEVICE_KEY)
 
 # Connect to WiFi
 wifi.connect()

--- a/minimqtt_certificate.py
+++ b/minimqtt_certificate.py
@@ -1,0 +1,125 @@
+import board
+import busio
+from digitalio import DigitalInOut
+import neopixel
+from adafruit_esp32spi import adafruit_esp32spi
+from adafruit_esp32spi import adafruit_esp32spi_wifimanager
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+
+from adafruit_minimqtt import MQTT
+
+### WiFi ###
+
+# Get wifi details and more from a secrets.py file
+try:
+    from secrets import secrets
+except ImportError:
+    print("WiFi secrets are kept in secrets.py, please add them there!")
+    raise
+
+# If you are using a board with pre-defined ESP32 Pins:
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
+
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D9)
+# esp32_ready = DigitalInOut(board.D10)
+# esp32_reset = DigitalInOut(board.D5)
+
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+"""Use below for Most Boards"""
+status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
+"""Uncomment below for ItsyBitsy M4"""
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+# Uncomment below for an externally defined RGB LED
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
+
+### Topic Setup ###
+
+# MQTT Topic
+# Use this topic if you'd like to connect to a standard MQTT broker
+mqtt_topic = 'test/topic'
+
+# Adafruit IO-style Topic
+# Use this topic if you'd like to connect to io.adafruit.com
+# mqtt_topic = 'aio_user/feeds/temperature'
+
+### Code ###
+
+# Define callback methods which are called when events occur
+# pylint: disable=unused-argument, redefined-outer-name
+def connect(client, userdata, flags, rc):
+    # This function will be called when the client is connected
+    # successfully to the broker.
+    print('Connected to MQTT Broker!')
+    print('Flags: {0}\n RC: {1}'.format(flags, rc))
+
+def disconnect(client, userdata, rc):
+    # This method is called when the client disconnects
+    # from the broker.
+    print('Disconnected from MQTT Broker!')
+
+def subscribe(client, userdata, topic, granted_qos):
+    # This method is called when the client subscribes to a new feed.
+    print('Subscribed to {0} with QOS level {1}'.format(topic, granted_qos))
+
+def unsubscribe(client, userdata, topic, pid):
+    # This method is called when the client unsubscribes from a feed.
+    print('Unsubscribed from {0} with PID {1}'.format(topic, pid))
+
+def publish(client, userdata, topic, pid):
+    # This method is called when the client publishes data to a feed.
+    print('Published to {0} with PID {1}'.format(topic, pid))
+
+# Get certificate and private key from a certificates.py file
+try:
+    from certificates import DEVICE_CERT, DEVICE_KEY
+except ImportError:
+    print("Certificate and private key data is kept in certificates.py, please add them there!")
+    raise
+
+# Set Device Certificate
+esp.set_certificate(CERT)
+
+# Set Private Key
+esp.set_private_key(KEY)
+
+# Connect to WiFi
+wifi.connect()
+
+# Set up a MiniMQTT Client
+client =  MQTT(socket,
+               broker = secrets['broker'],
+               username = secrets['user'],
+               password = secrets['pass'],
+               network_manager = wifi)
+
+# Connect callback handlers to client
+client.on_connect = connect
+client.on_disconnect = disconnect
+client.on_subscribe = subscribe
+client.on_unsubscribe = unsubscribe
+client.on_publish = publish
+
+print('Attempting to connect to %s'%client.broker)
+client.connect()
+
+print('Subscribing to %s'%mqtt_topic)
+client.subscribe(mqtt_topic)
+
+print('Publishing to %s'%mqtt_topic)
+client.publish(mqtt_topic, 'Hello Broker!')
+
+print('Unsubscribing from %s'%mqtt_topic)
+client.unsubscribe(mqtt_topic)
+
+print('Disconnecting from %s'%client.broker)
+client.disconnect()


### PR DESCRIPTION
Adding usage example for establishing a secure MQTT connection with a server, provided a user-defined X.509 certificate and private key.

**NOTE: This example requires nina-fw v1.4.0 or above.**  If you do not know how to upgrade the firmware on your ESP32, [follow the learn guide on the Adafruit Learning System for this topic](https://learn.adafruit.com/upgrading-esp32-firmware).
 

Example of usage, connecting to AWS IoT
```
code.py output:
Attempting to connect to GATEWAYNAME-ats.iot.us-east-2.amazonaws.com
Sending connect to broker
32 <--MQTT Auth Accepted by Broker
Connected to MQTT Broker!
Flags: 0
 RC: 0
Subscribing to test/topic
```