### PR TITLE
Fix Hostname Issue (#25)

### DIFF
--- a/adafruit_minimqtt.py
+++ b/adafruit_minimqtt.py
@@ -222,25 +222,9 @@ class MQTT:
         :param bool clean_session: Establishes a persistent session.
 
         """
-        try:
-            proto, dummy, broker, path = self.broker.split("/", 3)
-            # replace spaces in path
-            path = path.replace(" ", "%20")
-        except ValueError:
-            proto, dummy, broker = self.broker.split("/", 2)
-            path = ""
-        if proto == "http:":
-            self.port = MQTT_TCP_PORT
-        elif proto == "https:":
-            self.port = MQTT_TLS_PORT
-        else:
-            raise ValueError("Unsupported protocol: " + proto)
-
-        if ":" in broker:
-            broker, port = broker.split(":", 1)
-            port = int(port)
-
-        addr = _the_sock.getaddrinfo(broker, self.port, 0, _the_sock.SOCK_STREAM)[0]
+        addr = _the_sock.getaddrinfo(self.broker, self.port, 0, _the_sock.SOCK_STREAM)[
+            0
+        ]
         self._sock = _the_sock.socket(addr[0], addr[1], addr[2])
         self._sock.settimeout(15)
         if self.port == 8883:
@@ -249,7 +233,7 @@ class MQTT:
                     self.logger.debug(
                         "Attempting to establish secure MQTT connection..."
                     )
-                self._sock.connect((broker, self.port), _the_interface.TLS_MODE)
+                self._sock.connect((self.broker, self.port), _the_interface.TLS_MODE)
             except RuntimeError as e:
                 raise MMQTTException("Invalid broker address defined.", e)
         else:

--- a/examples/minimqtt_adafruitio_cellular.py
+++ b/examples/minimqtt_adafruitio_cellular.py
@@ -76,7 +76,7 @@ MQTT.set_socket(socket, fona)
 # Set up a MiniMQTT Client
 # NOTE: We'll need to connect insecurely for ethernet configurations.
 mqtt_client = MQTT.MQTT(
-    broker="http://io.adafruit.com",
+    broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
 )

--- a/examples/minimqtt_adafruitio_cellular.py
+++ b/examples/minimqtt_adafruitio_cellular.py
@@ -17,10 +17,8 @@ except ImportError:
 
 ### Cellular ###
 
-# Create a serial connection for the FONA connection using 4800 baud.
-# These are the defaults you should use for the FONA Shield.
-# For other boards set RX = GPS module TX, and TX = GPS module RX pins.
-uart = busio.UART(board.TX, board.RX, baudrate=4800)
+# Create a serial connection for the FONA connection
+uart = busio.UART(board.TX, board.RX)
 rst = digitalio.DigitalInOut(board.D4)
 # Initialize FONA
 fona = FONA(uart, rst)
@@ -79,6 +77,7 @@ mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    is_ssl=False,
 )
 
 # Setup the callback methods above

--- a/examples/minimqtt_adafruitio_eth.py
+++ b/examples/minimqtt_adafruitio_eth.py
@@ -64,6 +64,7 @@ mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
+    is_ssl=False,
 )
 
 # Setup the callback methods above

--- a/examples/minimqtt_adafruitio_eth.py
+++ b/examples/minimqtt_adafruitio_eth.py
@@ -61,7 +61,7 @@ MQTT.set_socket(socket, eth)
 # Set up a MiniMQTT Client
 # NOTE: We'll need to connect insecurely for ethernet configurations.
 mqtt_client = MQTT.MQTT(
-    broker="http://io.adafruit.com",
+    broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
 )

--- a/examples/minimqtt_adafruitio_wifi.py
+++ b/examples/minimqtt_adafruitio_wifi.py
@@ -89,7 +89,7 @@ MQTT.set_socket(socket, esp)
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
-    broker="http://io.adafruit.com",
+    broker="io.adafruit.com",
     username=secrets["aio_username"],
     password=secrets["aio_key"],
 )

--- a/examples/minimqtt_simpletest_cellular.py
+++ b/examples/minimqtt_simpletest_cellular.py
@@ -17,10 +17,8 @@ except ImportError:
     print("Cellular secrets are kept in secrets.py, please add them there!")
     raise
 
-# Create a serial connection for the FONA connection using 4800 baud.
-# These are the defaults you should use for the FONA Shield.
-# For other boards set RX = GPS module TX, and TX = GPS module RX pins.
-uart = busio.UART(board.TX, board.RX, baudrate=4800)
+# Create a serial connection for the FONA connection
+uart = busio.UART(board.TX, board.RX)
 rst = digitalio.DigitalInOut(board.D4)
 # Initialize FONA
 fona = FONA(uart, rst)
@@ -86,7 +84,10 @@ MQTT.set_socket(socket, fona)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(
-    broker=secrets["broker"], username=secrets["user"], password=secrets["pass"]
+    broker=secrets["broker"],
+    username=secrets["user"],
+    password=secrets["pass"],
+    is_ssl=False,
 )
 
 # Connect callback handlers to client


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/25

* Broker does not need HTTP/HTTPS URL since MQTT brokers will never start with `http://` or `https:/`
* Removed try/except block which improperly handles IP address strings
* Removed of `TCP_Mode`/`TLS_Mode` in favor of using the interface's tcp or tls mode.

Examples which need to be update to reflect this change
- [x]  Updated MMQTT library examples 
- [x] Updated Adafruit IO Library Examples 
- [x] Updated AzureIoT Library (sets broker within the library, not examples
- [x] Updated GCP IoT Core Library Examples 
https://github.com/adafruit/Adafruit_CircuitPython_GC_IOT_Core/pull/12