### PR TITLE
Fix import path in examples

### DIFF
--- a/examples/minimqtt_adafruitio_cellular.py
+++ b/examples/minimqtt_adafruitio_cellular.py
@@ -6,7 +6,7 @@ from adafruit_fona.adafruit_fona import FONA
 import adafruit_fona.adafruit_fona_network as network
 import adafruit_fona.adafruit_fona_socket as socket
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 # Get Adafruit IO details and more from a secrets.py file
 try:

--- a/examples/minimqtt_adafruitio_eth.py
+++ b/examples/minimqtt_adafruitio_eth.py
@@ -9,7 +9,7 @@ from digitalio import DigitalInOut
 from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 # Get Adafruit IO details and more from a secrets.py file
 try:

--- a/examples/minimqtt_adafruitio_wifi.py
+++ b/examples/minimqtt_adafruitio_wifi.py
@@ -10,7 +10,7 @@ from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###
 

--- a/examples/minimqtt_certificate.py
+++ b/examples/minimqtt_certificate.py
@@ -6,7 +6,7 @@ from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###
 

--- a/examples/minimqtt_pub_sub_blocking.py
+++ b/examples/minimqtt_pub_sub_blocking.py
@@ -8,7 +8,8 @@ import neopixel
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
-import adafruit_minimqtt as MQTT
+
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###
 

--- a/examples/minimqtt_pub_sub_blocking_topic_callbacks.py
+++ b/examples/minimqtt_pub_sub_blocking_topic_callbacks.py
@@ -6,6 +6,7 @@ import neopixel
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###

--- a/examples/minimqtt_pub_sub_nonblocking.py
+++ b/examples/minimqtt_pub_sub_nonblocking.py
@@ -6,7 +6,8 @@ import neopixel
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
-import adafruit_minimqtt as MQTT
+
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###
 

--- a/examples/minimqtt_pub_sub_pyportal.py
+++ b/examples/minimqtt_pub_sub_pyportal.py
@@ -1,8 +1,9 @@
 import time
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
-import adafruit_minimqtt as MQTT
 import adafruit_pyportal
+
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 pyportal = adafruit_pyportal.PyPortal()
 

--- a/examples/minimqtt_simpletest.py
+++ b/examples/minimqtt_simpletest.py
@@ -6,7 +6,7 @@ from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### WiFi ###
 

--- a/examples/minimqtt_simpletest_cellular.py
+++ b/examples/minimqtt_simpletest_cellular.py
@@ -6,7 +6,7 @@ from adafruit_fona.adafruit_fona import FONA
 import adafruit_fona.adafruit_fona_network as network
 import adafruit_fona.adafruit_fona_socket as socket
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 ### Cellular ###
 

--- a/examples/minimqtt_simpletest_eth.py
+++ b/examples/minimqtt_simpletest_eth.py
@@ -4,7 +4,7 @@ from digitalio import DigitalInOut
 from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 import adafruit_wiznet5k.adafruit_wiznet5k_socket as socket
 
-import adafruit_minimqtt as MQTT
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 # Get MQTT details and more from a secrets.py file
 try:


### PR DESCRIPTION
Addresses https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/40

This pull request:
* Changes import statements in code examples to reflect the library's modified path in release `3.1.0`