### PR TITLE
adjust fixed_header init; (-) loop_forever()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -460,13 +460,11 @@ class MQTT:
             0 <= qos <= 1
         ), "Quality of Service Level 2 is unsupported by this library."
 
-        pub_hdr_fixed = bytearray()  # fixed header
-        pub_hdr_fixed.extend(MQTT_PUB)
-        pub_hdr_fixed[0] |= retain | qos << 1  # [3.3.1.2], [3.3.1.3]
+        # fixed header. [3.3.1.2], [3.3.1.3]
+        pub_hdr_fixed = bytearray([MQTT_PUB[0] | retain | qos << 1])
 
-        pub_hdr_var = bytearray()  # variable header
-        pub_hdr_var.append(len(topic) >> 8)  # Topic length, MSB
-        pub_hdr_var.append(len(topic) & 0xFF)  # Topic length, LSB
+        # variable header = 2-byte Topic length (big endian)
+        pub_hdr_var = struct.pack('>H', len(topic))
         pub_hdr_var.extend(topic.encode("utf-8"))  # Topic name
 
         remaining_length = 2 + len(msg) + len(topic)

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -303,8 +303,7 @@ class MQTT:
                 raise MMQTTException("Invalid broker address defined.", e)
 
         # Fixed Header
-        fixed_header = bytearray()
-        fixed_header.append(0x10)
+        fixed_header = bytearray([0x10])
 
         # NOTE: Variable header is
         # MQTT_HDR_CONNECT = bytearray(b"\x04MQTT\x04\x02\0\0")
@@ -687,21 +686,6 @@ class MQTT:
             while subscribed_topics:
                 feed = subscribed_topics.pop()
                 self.subscribe(feed)
-
-    def loop_forever(self):
-        """Starts a blocking message loop. Use this
-        method if you want to run a program forever.
-        Code below a call to this method will NOT execute.
-
-        .. note:: This method is depreciated and will be removed in the
-            next major release. Please see
-            `examples/minimqtt_pub_sub_blocking.py <examples.html#basic-forever-loop>`_
-            for an example of creating a blocking loop which can handle wireless
-            network events.
-        """
-        while True:
-            if self._sock.connected:
-                self.loop()
 
     def loop(self):
         """Non-blocking message loop. Use this method to

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -464,7 +464,7 @@ class MQTT:
         pub_hdr_fixed = bytearray([MQTT_PUB[0] | retain | qos << 1])
 
         # variable header = 2-byte Topic length (big endian)
-        pub_hdr_var = struct.pack('>H', len(topic))
+        pub_hdr_var = struct.pack(">H", len(topic))
         pub_hdr_var.extend(topic.encode("utf-8"))  # Topic name
 
         remaining_length = 2 + len(msg) + len(topic)

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -464,7 +464,7 @@ class MQTT:
 
         # variable header = 2-byte Topic length (big endian)
         pub_hdr_var = bytearray(struct.pack(">H", len(topic)))
-        pub_hdr_var.append(topic.encode("utf-8"))  # Topic name
+        pub_hdr_var.extend(topic.encode("utf-8"))  # Topic name
 
         remaining_length = 2 + len(msg) + len(topic)
         if qos > 0:

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -62,7 +62,6 @@ MQTT_PINGREQ = b"\xc0\0"
 MQTT_PINGRESP = const(0xD0)
 MQTT_SUB = b"\x82"
 MQTT_UNSUB = b"\xA2"
-MQTT_PUB = bytearray(b"\x30")
 MQTT_DISCONNECT = b"\xe0\0"
 
 # Variable CONNECT header [MQTT 3.1.2]
@@ -461,11 +460,11 @@ class MQTT:
         ), "Quality of Service Level 2 is unsupported by this library."
 
         # fixed header. [3.3.1.2], [3.3.1.3]
-        pub_hdr_fixed = bytearray([MQTT_PUB[0] | retain | qos << 1])
+        pub_hdr_fixed = bytearray([0x30 | retain | qos << 1])
 
         # variable header = 2-byte Topic length (big endian)
-        pub_hdr_var = struct.pack(">H", len(topic))
-        pub_hdr_var.extend(topic.encode("utf-8"))  # Topic name
+        pub_hdr_var = bytearray(struct.pack(">H", len(topic)))
+        pub_hdr_var.append(topic.encode("utf-8"))  # Topic name
 
         remaining_length = 2 + len(msg) + len(topic)
         if qos > 0:


### PR DESCRIPTION
@brentru This should now be rebased upon the adafruit master branch.
changes include:
* removed deprecated `loop_forever()` in preparation for next major release.
* consolidated the `fixed_header` initialization to 1 line of code.