### PR TITLE
payload parameter of type `None` replaced with zero-length string in `will_set()`

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -217,7 +217,7 @@ class MQTT:
         if self._is_connected:
             raise MMQTTException("Last Will should only be called before connect().")
         if payload is None:
-            raise MMQTTException("Message can not be None.")
+            payload = ""
         if isinstance(payload, (int, float, str)):
             payload = str(payload).encode()
         else:


### PR DESCRIPTION
satisfies #39 in accordance with paho_mqtt library compatibility

I tested this fix locally (on my trusty ItsyBitsy M4) without connection to a broker. The only esp32 I have lying around is a TinyPico, so properly testing this on my end might be a bit taxing for a 1-line fix. If there's an easier way to test this with a Raspberry Pi, I'd gladly dust off my old RPi.

I followed the data from the `payload` parameter through the code to see if this fix instigates another issue, and I found no problems. However, I'm not sure about `self._sock.send(string)` where `self._lw_msg` (instance attribute that holds the zero-length string when payload parameter is of type `None`) is passed as the `string` parameter in [`_send_str()`](https://github.com/2bndy5/Adafruit_CircuitPython_MiniMQTT/blob/95f9519333d53a426b89c7194d1f843b4863f1fd/adafruit_minimqtt/adafruit_minimqtt.py#L778). BTW, I have verified that `self._lw_msg` becomes `b''` (empty bytearray) when calling `will_set()` using parameters' defaults with this fix. 

### TL;DR 
All this to say that the success of this fix depends on the socket interface's ability to send an empty bytearray.