### PR TITLE
Adafruit Logging is required

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Dependencies
 This driver depends on:
 
 * `Adafruit CircuitPython <https://github.com/adafruit/circuitpython>`_
+* `Adafruit Logging <https://github.com/adafruit/Adafruit_CircuitPython_Logging>`_
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -246,7 +246,7 @@ class MQTT:
         try:
             del self._on_message_filtered[mqtt_topic]
         except KeyError:
-            raise from KeyError("MQTT topic callback not added with add_topic_callback.")
+            raise KeyError("MQTT topic callback not added with add_topic_callback.") from None
 
     @property
     def on_message(self):
@@ -287,7 +287,7 @@ class MQTT:
                 conntype = _the_interface.TLS_MODE
                 self._sock.connect((self.broker, self.port), conntype)
             except RuntimeError as e:
-                raise from MMQTTException("Invalid broker address defined.", e)
+                raise MMQTTException("Invalid broker address defined.", e) from None
         else:
             try:
                 if self.logger is not None:
@@ -299,7 +299,7 @@ class MQTT:
                 )[0]
                 self._sock.connect(addr[-1], _the_interface.TCP_MODE)
             except RuntimeError as e:
-                raise from MMQTTException("Invalid broker address defined.", e)
+                raise MMQTTException("Invalid broker address defined.", e) from None
 
         # Fixed Header
         fixed_header = bytearray([0x10])

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -246,7 +246,9 @@ class MQTT:
         try:
             del self._on_message_filtered[mqtt_topic]
         except KeyError:
-            raise KeyError("MQTT topic callback not added with add_topic_callback.") from None
+            raise KeyError(
+                "MQTT topic callback not added with add_topic_callback."
+            ) from None
 
     @property
     def on_message(self):

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -246,7 +246,7 @@ class MQTT:
         try:
             del self._on_message_filtered[mqtt_topic]
         except KeyError:
-            raise KeyError("MQTT topic callback not added with add_topic_callback.")
+            raise from KeyError("MQTT topic callback not added with add_topic_callback.")
 
     @property
     def on_message(self):
@@ -287,7 +287,7 @@ class MQTT:
                 conntype = _the_interface.TLS_MODE
                 self._sock.connect((self.broker, self.port), conntype)
             except RuntimeError as e:
-                raise MMQTTException("Invalid broker address defined.", e)
+                raise from MMQTTException("Invalid broker address defined.", e)
         else:
             try:
                 if self.logger is not None:
@@ -299,7 +299,7 @@ class MQTT:
                 )[0]
                 self._sock.connect(addr[-1], _the_interface.TCP_MODE)
             except RuntimeError as e:
-                raise MMQTTException("Invalid broker address defined.", e)
+                raise from MMQTTException("Invalid broker address defined.", e)
 
         # Fixed Header
         fixed_header = bytearray([0x10])

--- a/adafruit_minimqtt/matcher.py
+++ b/adafruit_minimqtt/matcher.py
@@ -55,7 +55,7 @@ class MQTTMatcher:
                 raise KeyError(key)
             return node.content
         except KeyError:
-            raise KeyError(key)
+            raise from KeyError(key)
 
     def __delitem__(self, key):
         """Delete the value associated with some topic filter :key"""
@@ -67,7 +67,7 @@ class MQTTMatcher:
                 lst.append((parent, k, node))
             node.content = None
         except KeyError:
-            raise KeyError(key)
+            raise from KeyError(key)
         else:  # cleanup
             for parent, k, node in reversed(lst):
                 if node.children or node.content is not None:

--- a/adafruit_minimqtt/matcher.py
+++ b/adafruit_minimqtt/matcher.py
@@ -55,7 +55,7 @@ class MQTTMatcher:
                 raise KeyError(key)
             return node.content
         except KeyError:
-            raise from KeyError(key)
+            raise KeyError(key) from None
 
     def __delitem__(self, key):
         """Delete the value associated with some topic filter :key"""
@@ -67,7 +67,7 @@ class MQTTMatcher:
                 lst.append((parent, k, node))
             node.content = None
         except KeyError:
-            raise from KeyError(key)
+            raise KeyError(key) from None
         else:  # cleanup
             for parent, k, node in reversed(lst):
                 if node.children or node.content is not None:


### PR DESCRIPTION

```python
Adafruit CircuitPython 5.0.0-beta.0-2634-gda61845f5-dirty on 2020-08-24; FeatherS2 with ESP32S2
>>> import os
>>> os.listdir('/lib')
['adafruit_requests.mpy', 'adafruit_azureiot', '._adafruit_azureiot', 'adafruit_minimqtt', '._adafruit_minimqtt', 'adafruit_binascii.mpy', '._adafruit_binascii.mpy', 'adafruit_ntp.mpy', '._adafruit_ntp.mpy']
>>> import adafruit_minimqtt.adafruit_minimqtt as MINIQTT
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 47, in <module>
ImportError: no module named 'adafruit_logging'

```