### PR TITLE
Update CPython example for secure MQTT broker port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       run: |
         pylint $( find . -path './adafruit*.py' )
         ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
+        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles

--- a/examples/cpython/minimqtt_simpletest_cpython.py
+++ b/examples/cpython/minimqtt_simpletest_cpython.py
@@ -34,26 +34,32 @@ def connect(mqtt_client, userdata, flags, rc):
     print("Connected to MQTT Broker!")
     print("Flags: {0}\n RC: {1}".format(flags, rc))
 
+
 def disconnect(mqtt_client, userdata, rc):
     # This method is called when the mqtt_client disconnects
     # from the broker.
     print("Disconnected from MQTT Broker!")
 
+
 def subscribe(mqtt_client, userdata, topic, granted_qos):
     # This method is called when the mqtt_client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
+
 
 def unsubscribe(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client unsubscribes from a feed.
     print("Unsubscribed from {0} with PID {1}".format(topic, pid))
 
+
 def publish(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client publishes data to a feed.
     print("Published to {0} with PID {1}".format(topic, pid))
 
+
 def message(client, topic, message):
     # Method callled when a client's subscribed feed has a new value.
     print("New message on topic {0}: {1}".format(topic, message))
+
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
@@ -61,7 +67,7 @@ mqtt_client = MQTT.MQTT(
     username=secrets["aio_username"],
     password=secrets["aio_key"],
     socket_pool=socket,
-    ssl_context=ssl.create_default_context()
+    ssl_context=ssl.create_default_context(),
 )
 
 # Connect callback handlers to mqtt_client

--- a/examples/cpython/minimqtt_simpletest_cpython.py
+++ b/examples/cpython/minimqtt_simpletest_cpython.py
@@ -1,32 +1,31 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import ssl
 import socket
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-### Secrets File Setup ###
-
+# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
+# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# source control.
+# pylint: disable=no-name-in-module,wrong-import-order
 try:
     from secrets import secrets
 except ImportError:
-    print("Connection secrets are kept in secrets.py, please add them there!")
+    print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
 ### Topic Setup ###
 
 # MQTT Topic
 # Use this topic if you'd like to connect to a standard MQTT broker
-# mqtt_topic = "test/topic"
+mqtt_topic = "test/topic"
 
 # Adafruit IO-style Topic
 # Use this topic if you'd like to connect to io.adafruit.com
-mqtt_topic = secrets["aio_username"] + "/feeds/temperature"
+# mqtt_topic = secrets["aio_username"] + "/feeds/temperature"
 
 ### Code ###
-
-# Keep track of client connection state
-disconnect_client = False
-
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name
 def connect(mqtt_client, userdata, flags, rc):
@@ -35,40 +34,34 @@ def connect(mqtt_client, userdata, flags, rc):
     print("Connected to MQTT Broker!")
     print("Flags: {0}\n RC: {1}".format(flags, rc))
 
-
 def disconnect(mqtt_client, userdata, rc):
     # This method is called when the mqtt_client disconnects
     # from the broker.
     print("Disconnected from MQTT Broker!")
 
-
 def subscribe(mqtt_client, userdata, topic, granted_qos):
     # This method is called when the mqtt_client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
-
 
 def unsubscribe(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client unsubscribes from a feed.
     print("Unsubscribed from {0} with PID {1}".format(topic, pid))
 
-
 def publish(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client publishes data to a feed.
     print("Published to {0} with PID {1}".format(topic, pid))
-
 
 def message(client, topic, message):
     # Method callled when a client's subscribed feed has a new value.
     print("New message on topic {0}: {1}".format(topic, message))
 
-
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
     broker=secrets["broker"],
-    port=1883,
     username=secrets["aio_username"],
     password=secrets["aio_key"],
     socket_pool=socket,
+    ssl_context=ssl.create_default_context()
 )
 
 # Connect callback handlers to mqtt_client


### PR DESCRIPTION
Addresses https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/62 by updating simpletest_cpython example to include correct constructor and import cpython's `ssl` module.

Tested on CPython 3.9.1
```
❯ python3 test_cpython.py
Attempting to connect to io.adafruit.com
Connected to MQTT Broker!
Flags: 0
 RC: 0
Subscribing to brubell/feeds/temperature
Subscribed to brubell/feeds/temperature with QOS level 0
Publishing to brubell/feeds/temperature
Published to brubell/feeds/temperature with PID 1
Unsubscribing from brubell/feeds/temperature
Unsubscribed from brubell/feeds/temperature with PID 2
Disconnecting from io.adafruit.com
Disconnected from MQTT Broker!```