### PR TITLE
Fix CPython/Legacy Socket SSL Problems

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,7 @@ jobs:
       run: |
         pylint $( find . -path './adafruit*.py' )
         ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*.py" ))
+        ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace $( find . -path "./examples/*/*.py" ))
     - name: Build assets
       run: circuitpython-build-bundles --filename_prefix ${{ steps.repo-name.outputs.repo-name }} --library_location .
     - name: Archive bundles

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -203,8 +203,8 @@ class MQTT:
         self.on_subscribe = None
         self.on_unsubscribe = None
 
-    def _get_socket(self, host, port, *, timeout=1):
-        """Obtains and connects a new socket to a host.
+    def _get_connect_socket(self, host, port, *, timeout=1):
+        """Obtains a new socket and connects to a broker.
         :param str host: Desired broker hostname
         :param int port: Desired broker port
         :param int timeout: Desired socket timeout
@@ -214,7 +214,7 @@ class MQTT:
             self._sock.close()
             self._sock = None
 
-        # Legacy API - use a default socket instead of socket pool
+        # Legacy API - use the interface's socket instead of a passed socket pool
         if self._socket_pool is None:
             self._socket_pool = _default_sock
 
@@ -222,7 +222,7 @@ class MQTT:
         if self._ssl_context is None:
             self._ssl_context = _fake_context
 
-        if port == 8883 and self._ssl_context is None:
+        if port == 8883 and not self._ssl_context:
             raise RuntimeError(
                 "ssl_context must be set before using adafruit_mqtt for secure MQTT."
             )
@@ -425,7 +425,7 @@ class MQTT:
             self.logger.debug("Attempting to establish MQTT connection...")
 
         # Get a new socket
-        self._sock = self._get_socket(self.broker, self.port)
+        self._sock = self._get_connect_socket(self.broker, self.port)
 
         # Fixed Header
         fixed_header = bytearray([0x10])

--- a/examples/cpython/minimqtt_simpletest_cpython.py
+++ b/examples/cpython/minimqtt_simpletest_cpython.py
@@ -34,26 +34,32 @@ def connect(mqtt_client, userdata, flags, rc):
     print("Connected to MQTT Broker!")
     print("Flags: {0}\n RC: {1}".format(flags, rc))
 
+
 def disconnect(mqtt_client, userdata, rc):
     # This method is called when the mqtt_client disconnects
     # from the broker.
     print("Disconnected from MQTT Broker!")
 
+
 def subscribe(mqtt_client, userdata, topic, granted_qos):
     # This method is called when the mqtt_client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
+
 
 def unsubscribe(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client unsubscribes from a feed.
     print("Unsubscribed from {0} with PID {1}".format(topic, pid))
 
+
 def publish(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client publishes data to a feed.
     print("Published to {0} with PID {1}".format(topic, pid))
 
+
 def message(client, topic, message):
     # Method callled when a client's subscribed feed has a new value.
     print("New message on topic {0}: {1}".format(topic, message))
+
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
@@ -61,7 +67,7 @@ mqtt_client = MQTT.MQTT(
     username=secrets["aio_username"],
     password=secrets["aio_key"],
     socket_pool=socket,
-    ssl_context=ssl.create_default_context()
+    ssl_context=ssl.create_default_context(),
 )
 
 # Connect callback handlers to mqtt_client

--- a/examples/cpython/minimqtt_simpletest_cpython.py
+++ b/examples/cpython/minimqtt_simpletest_cpython.py
@@ -1,32 +1,31 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import ssl
 import socket
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-### Secrets File Setup ###
-
+# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
+# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# source control.
+# pylint: disable=no-name-in-module,wrong-import-order
 try:
     from secrets import secrets
 except ImportError:
-    print("Connection secrets are kept in secrets.py, please add them there!")
+    print("WiFi secrets are kept in secrets.py, please add them there!")
     raise
 
 ### Topic Setup ###
 
 # MQTT Topic
 # Use this topic if you'd like to connect to a standard MQTT broker
-# mqtt_topic = "test/topic"
+mqtt_topic = "test/topic"
 
 # Adafruit IO-style Topic
 # Use this topic if you'd like to connect to io.adafruit.com
-mqtt_topic = secrets["aio_username"] + "/feeds/temperature"
+# mqtt_topic = secrets["aio_username"] + "/feeds/temperature"
 
 ### Code ###
-
-# Keep track of client connection state
-disconnect_client = False
-
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name
 def connect(mqtt_client, userdata, flags, rc):
@@ -35,40 +34,34 @@ def connect(mqtt_client, userdata, flags, rc):
     print("Connected to MQTT Broker!")
     print("Flags: {0}\n RC: {1}".format(flags, rc))
 
-
 def disconnect(mqtt_client, userdata, rc):
     # This method is called when the mqtt_client disconnects
     # from the broker.
     print("Disconnected from MQTT Broker!")
 
-
 def subscribe(mqtt_client, userdata, topic, granted_qos):
     # This method is called when the mqtt_client subscribes to a new feed.
     print("Subscribed to {0} with QOS level {1}".format(topic, granted_qos))
-
 
 def unsubscribe(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client unsubscribes from a feed.
     print("Unsubscribed from {0} with PID {1}".format(topic, pid))
 
-
 def publish(mqtt_client, userdata, topic, pid):
     # This method is called when the mqtt_client publishes data to a feed.
     print("Published to {0} with PID {1}".format(topic, pid))
-
 
 def message(client, topic, message):
     # Method callled when a client's subscribed feed has a new value.
     print("New message on topic {0}: {1}".format(topic, message))
 
-
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
     broker=secrets["broker"],
-    port=1883,
     username=secrets["aio_username"],
     password=secrets["aio_key"],
     socket_pool=socket,
+    ssl_context=ssl.create_default_context()
 )
 
 # Connect callback handlers to mqtt_client


### PR DESCRIPTION
This pull request:
* Sets `_FakeSSLContext` within calls to `set_interface` instead of within `__init__`
* Removes socket reuse code mirrored in from `adafruit-circuitpython-requests` 
* Calls to `reconnect` now close an open socket
* Legacy socket API set up in `_get_connect_socket` instead of within `__init__`
* Updated `examples/cpython/minimqtt_simpletest_cpython` to address #62 

Addresses https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/62

Tested on: ESP32SPI (PyPortal), CPython, and ESP32-S2 (Metro ESP32-S2)