### PR TITLE
Make loop() in esp32spi implementation non-blocking

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -911,7 +911,7 @@ class MQTT:
             read_timeout = self.keep_alive
             # This will timeout with socket timeout (not keepalive timeout)
             rc = self._sock.recv(bufsize)
-            if(not rc):
+            if not rc:
                 if self.logger:
                     self.logger.debug("_sock_exact_recv timeout")
                 # If no bytes waiting, raise same exception as socketpool

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -909,12 +909,16 @@ class MQTT:
         else:  # ESP32SPI Impl.
             stamp = time.monotonic()
             read_timeout = self.keep_alive
-            rc = self._sock.recv(bufsize) # This will timeout with socket timeout (not keepalive timeout)
+            # This will timeout with socket timeout (not keepalive timeout)
+            rc = self._sock.recv(bufsize)
             if(not rc):
                 if self.logger:
                     self.logger.debug("_sock_exact_recv timeout")
-                raise OSError(errno.ETIMEDOUT) # If no bytes waiting, raise same exception as socketpool
-            to_read = bufsize - len(rc) # If any bytes waiting, try to read them all
+                # If no bytes waiting, raise same exception as socketpool
+                raise OSError(errno.ETIMEDOUT)
+            # If any bytes waiting, try to read them all,
+            # or raise exception if wait longer than read_timeout
+            to_read = bufsize - len(rc)
             assert to_read >= 0
             read_timeout = self.keep_alive
             while to_read > 0:

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -510,7 +510,7 @@ class MQTT:
         if self.logger:
             self.logger.debug("Sending CONNECT to broker...")
             self.logger.debug(
-                "Fixed Header: %x\nVariable Header: %x", fixed_header, var_header
+                "Fixed Header: %s\nVariable Header: %s", fixed_header, var_header
             )
         self._sock.send(fixed_header)
         self._sock.send(var_header)
@@ -634,7 +634,7 @@ class MQTT:
 
         if self.logger:
             self.logger.debug(
-                "Sending PUBLISH\nTopic: %s\nMsg: %x\
+                "Sending PUBLISH\nTopic: %s\nMsg: %s\
                                 \nQoS: %d\nRetain? %r",
                 topic,
                 msg,
@@ -803,8 +803,7 @@ class MQTT:
             # Handle KeepAlive by expecting a PINGREQ/PINGRESP from the server
             if self.logger is not None:
                 self.logger.debug(
-                    "KeepAlive period elapsed - \
-                                   requesting a PINGRESP from the server..."
+                    "KeepAlive period elapsed - requesting a PINGRESP from the server..."
                 )
             rcs = self.ping()
             self._timestamp = 0
@@ -826,7 +825,7 @@ class MQTT:
                 res = self._sock_exact_recv(1)
             except OSError as error:
                 if error.errno == errno.ETIMEDOUT:
-                    # raised by a socket timeout in socketpool
+                    # raised by a socket timeout if 0 bytes were present
                     return None
                 raise MMQTTException from error
 
@@ -837,7 +836,7 @@ class MQTT:
             return None
         if res[0] == MQTT_PINGRESP:
             if self.logger:
-                self.logger.debug("Checking PINGRESP")
+                self.logger.debug("Got PINGRESP")
             sz = self._sock_exact_recv(1)[0]
             if sz != 0x00:
                 raise MMQTTException(
@@ -910,8 +909,12 @@ class MQTT:
         else:  # ESP32SPI Impl.
             stamp = time.monotonic()
             read_timeout = self.keep_alive
-            rc = self._sock.recv(bufsize)
-            to_read = bufsize - len(rc)
+            rc = self._sock.recv(bufsize) # This will timeout with socket timeout (not keepalive timeout)
+            if(not rc):
+                if self.logger:
+                    self.logger.debug("_sock_exact_recv timeout")
+                raise OSError(errno.ETIMEDOUT) # If no bytes waiting, raise same exception as socketpool
+            to_read = bufsize - len(rc) # If any bytes waiting, try to read them all
             assert to_read >= 0
             read_timeout = self.keep_alive
             while to_read > 0:


### PR DESCRIPTION
Have been having a discussion with @brentru about an issue with the esp32spi implementation of `loop()` always blocking until the end of the keepalive period. We think raising `OSError(errno.ETIMEDOUT)` at the right point may fix that issue. Also replaces some `%x` format codes with `%s` in the logging statements because `bytearray`s can't be formatted with `%s`. (The `%s` is ugly but it works.)