### PR TITLE
Validate port is integer type for SocketPool

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -203,6 +203,7 @@ class MQTT:
         self.on_subscribe = None
         self.on_unsubscribe = None
 
+    # pylint: disable=too-many-branches
     def _get_connect_socket(self, host, port, *, timeout=1):
         """Obtains a new socket and connects to a broker.
         :param str host: Desired broker hostname
@@ -221,6 +222,9 @@ class MQTT:
         # Legacy API - fake the ssl context
         if self._ssl_context is None:
             self._ssl_context = _fake_context
+
+        if not isinstance(port, int):
+            raise RuntimeError("Port must be an integer")
 
         if port == 8883 and not self._ssl_context:
             raise RuntimeError(


### PR DESCRIPTION
While ESP32-SPI's socket validates if a user passes an invalid port value:
```
code.py output:
Connecting to WiFi...
Connected!
Connecting to Adafruit IO...
Traceback (most recent call last):
  File "code.py", line 105, in <module>
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 437, in connect
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 240, in _get_connect_socket
  File "/lib/adafruit_esp32spi/adafruit_esp32spi_socket.py", line 42, in getaddrinfo
RuntimeError: Port must be an integer
```

https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/76 found that native socketpool does not validate port data type before connecting. When entering the port # in the `secrets.py` file, it may be not clear to people that `port` requires an integer value while most other values within the file require a string value.

This pull request mirrors ESP32SPI's `RuntimeError` thrown when using a string as a port number into this library:
```
code.py output:
Connecting to WiFi...
Connected!
Connecting to Adafruit IO...
Traceback (most recent call last):
  File "code.py", line 105, in <module>
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 440, in connect
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 226, in _get_connect_socket
RuntimeError: Port must be an integer
```
