### PR TITLE
MQTT QOS=1,2 rules state that pid must be > 0.

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -591,9 +591,9 @@ class MQTT:
         if qos > 0:
             # packet identifier where QoS level is 1 or 2. [3.3.2.2]
             remaining_length += 2
-            pub_hdr_var.append(0x00)
-            pub_hdr_var.append(self._pid)
-            self._pid += 1
+            self._pid = self._pid + 1 if self._pid < 0xFFFF else 1
+            pub_hdr_var.append(self._pid >> 8)
+            pub_hdr_var.append(self._pid & 0xFF)
 
         # Calculate remaining length [2.2.3]
         if remaining_length > 0x7F:
@@ -668,7 +668,7 @@ class MQTT:
         packet_length = 2 + (2 * len(topics)) + (1 * len(topics))
         packet_length += sum(len(topic) for topic, qos in topics)
         packet_length_byte = packet_length.to_bytes(1, "big")
-        self._pid += 1
+        self._pid = self._pid + 1 if self._pid < 0xFFFF else 1
         packet_id_bytes = self._pid.to_bytes(2, "big")
         # Packet with variable and fixed headers
         packet = MQTT_SUB + packet_length_byte + packet_id_bytes
@@ -717,7 +717,7 @@ class MQTT:
         packet_length = 2 + (2 * len(topics))
         packet_length += sum(len(topic) for topic in topics)
         packet_length_byte = packet_length.to_bytes(1, "big")
-        self._pid += 1
+        self._pid = self._pid + 1 if self._pid < 0xFFFF else 1
         packet_id_bytes = self._pid.to_bytes(2, "big")
         packet = MQTT_UNSUB + packet_length_byte + packet_id_bytes
         for t in topics:


### PR DESCRIPTION
Publishing with QOS 1 seemed to be broken because PID was incremented immediately *after* putting into packet, meaning that the PUBACK packet would not match the new (incremented) PID.

There is a danger if publishing more than 0xFFFF packets that .to_bytes will fail because it can't pack into 2 bytes after that. PID must wrap around to 1, not 0, according to spec, which demands that PID be nonzero for QOS 1 and 2.