### PR TITLE
adafruit_minimqtt: Fix issue #86 with multiple poll() PINGREQs

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -776,13 +776,13 @@ class MQTT:
             self._timestamp = time.monotonic()
         current_time = time.monotonic()
         if current_time - self._timestamp >= self.keep_alive:
+            self._timestamp = 0
             # Handle KeepAlive by expecting a PINGREQ/PINGRESP from the server
             if self.logger is not None:
                 self.logger.debug(
                     "KeepAlive period elapsed - requesting a PINGRESP from the server..."
                 )
             rcs = self.ping()
-            self._timestamp = 0
             return rcs
         self._sock.settimeout(timeout)
         rc = self._wait_for_msg()


### PR DESCRIPTION
If I set timeout to zero there is a problem as the poll() call will be
called multiple times while a ping request is outstanding and this
results in multiple ping requests being made. I see 3-5 at a time with
DEBUG logging on.

This is because self._timestamp is being reset after self.ping()

The solution seems to be pretty straightforward which is to reset
self._timestamp() before sending the ping()

Signed-off-by: Alex J Lennon <ajlennon@dynamicdevices.co.uk>