### PR TITLE
Fix Issue #90: Remaining length issues

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -459,7 +459,7 @@ class MQTT:
             var_header[7] |= self.keep_alive >> 8
             var_header[8] |= self.keep_alive & 0x00FF
         if self._lw_topic:
-            remaining_length += 2 + len(self._lw_topic.encode("utf-8")) + 2 + len(self._lw_msg.encode("utf-8"))
+            remaining_length += 2 + len(self._lw_topic.encode("utf-8")) + 2 + len(self._lw_msg)
             var_header[6] |= 0x4 | (self._lw_qos & 0x1) << 3 | (self._lw_qos & 0x2) << 3
             var_header[6] |= self._lw_retain << 5
 
@@ -914,10 +914,11 @@ class MQTT:
         :param str string: String to write to the socket.
 
         """
-        self._sock.send(struct.pack("!H", len(string.encode("utf-8"))))
         if isinstance(string, str):
+            self._sock.send(struct.pack("!H", len(string.encode("utf-8"))))
             self._sock.send(str.encode(string, "utf-8"))
         else:
+            self._sock.send(struct.pack("!H", len(string)))
             self._sock.send(string)
 
     @staticmethod

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -576,7 +576,7 @@ class MQTT:
             pass
         else:
             raise MMQTTException("Invalid message data type.")
-        if len(msg.encode("utf-8")) > MQTT_MSG_MAX_SZ:
+        if len(msg) > MQTT_MSG_MAX_SZ:
             raise MMQTTException("Message size larger than %d bytes." % MQTT_MSG_MAX_SZ)
         assert (
             0 <= qos <= 1
@@ -589,7 +589,7 @@ class MQTT:
         pub_hdr_var = bytearray(struct.pack(">H", len(topic.encode("utf-8"))))
         pub_hdr_var.extend(topic.encode("utf-8"))  # Topic name
 
-        remaining_length = 2 + len(msg.encode("utf-8")) + len(topic.encode("utf-8"))
+        remaining_length = 2 + len(msg) + len(topic.encode("utf-8"))
         if qos > 0:
             # packet identifier where QoS level is 1 or 2. [3.3.2.2]
             remaining_length += 2

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -64,6 +64,13 @@ CONNACK_ERRORS = {
 _default_sock = None  # pylint: disable=invalid-name
 _fake_context = None  # pylint: disable=invalid-name
 
+# Override default len() method
+len_overrided = len
+def len(object):
+    if isinstance(object, str):
+        return len_overrided(object.encode('utf-8'))
+    else:
+        return len_overrided(object)
 
 class MMQTTException(Exception):
     """MiniMQTT Exception class."""


### PR DESCRIPTION
https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/90#issue-981092769
I override the default len() method. Now, when calculating the length of a string, it will return the length of the UTF-8 encoded bytes instead of the number of characters.
This change will not affect the calculation of English string length. However, when dealing with certain languages, it helps a lot.
For example, "中文" in UTF-8 encoded bytes is "\xe4\xb8\xad\xe6\x96\x87". Previously, len("中文") is 2 (incorrect). After override, len("中文") is 6 (len(b'\xe4\xb8\xad\xe6\x96\x87'), correct).
Because there are too many uses of len(str) in the code, I carried out this override to fix them at a time. After confirming that the issue I raised is valid, maybe you can have a more professional and elegant way to fix it.
Thank you very much.