### PR TITLE
Remove last arg from .socket() call

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -250,9 +250,7 @@ class MQTT:
             retry_count += 1
 
             try:
-                sock = self._socket_pool.socket(
-                    addr_info[0], addr_info[1], addr_info[2]
-                )
+                sock = self._socket_pool.socket(addr_info[0], addr_info[1])
             except OSError:
                 continue
 


### PR DESCRIPTION
Analogous fix in this library to https://github.com/adafruit/Adafruit_CircuitPython_Requests/pull/82.

`SocketPool.socket()` only takes two arguments, but three were being passed. Because of adafruit/circuitpython#5439, this went undetected until recently.

Tagging @tannewt for interest.