### PR TITLE
feat: add support for binary messages

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -126,6 +126,7 @@ class MQTT:
     :param int keep_alive: KeepAlive interval between the broker and the MiniMQTT client.
     :param socket socket_pool: A pool of socket resources available for the given radio.
     :param ssl_context: SSL context for long-lived SSL connections.
+    :param bool use_binary_mode: Messages are passed as bytearray instead of string to callbacks.
 
     """
 
@@ -141,12 +142,14 @@ class MQTT:
         keep_alive=60,
         socket_pool=None,
         ssl_context=None,
+        use_binary_mode=False,
     ):
 
         self._socket_pool = socket_pool
         self._ssl_context = ssl_context
         self._sock = None
         self._backwards_compatible_sock = False
+        self._use_binary_mode = use_binary_mode
 
         self.keep_alive = keep_alive
         self._user_data = None
@@ -839,8 +842,9 @@ class MQTT:
             pid = pid[0] << 0x08 | pid[1]
             sz -= 0x02
         # read message contents
-        msg = self._sock_exact_recv(sz)
-        self._handle_on_message(self, topic, str(msg, "utf-8"))
+        raw_msg = self._sock_exact_recv(sz)
+        msg = raw_msg if self._use_binary_mode else str(raw_msg, "utf-8")
+        self._handle_on_message(self, topic, msg)
         if res[0] & 0x06 == 0x02:
             pkt = bytearray(b"\x40\x02\0\0")
             struct.pack_into("!H", pkt, 2, pid)


### PR DESCRIPTION
I'm creating a basic client library to use with [Golioth](https://golioth.io) Platform. We recently added a new gateway to support MQTT devices and that allows us to add support to CircuitPython.

But while developing the client, we had issues with one of our services meant for Over the Air Updates, which serves not only for the main device firmware, but you can send any arbitrary artifact ( like images/bitmap in my testing here). Currently, this MQTT library tries to convert all messages to a Unicode string, which unfortunately fails for binary data. Reference to where it fails: https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/blob/main/adafruit_minimqtt/adafruit_minimqtt.py#L843

So what I'm proposing here is to add an optional parameter called `use_binary`, that would allow users to use the MQTT client in binary mode and return the raw `bytearray` message. Them is up to the user to convert to a string as needed.