### PR TITLE
allow to set socket timeout

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -214,12 +214,12 @@ class MQTT:
         self.on_unsubscribe = None
 
     # pylint: disable=too-many-branches
-    def _get_connect_socket(self, host, port, *, timeout):
+    def _get_connect_socket(self, host, port, *, timeout=1):
         """Obtains a new socket and connects to a broker.
 
         :param str host: Desired broker hostname
         :param int port: Desired broker port
-        :param int timeout: Desired socket timeout in seconds
+        :param int timeout: Desired socket timeout, in seconds
         """
         # For reconnections - check if we're using a socket already and close it
         if self._sock:

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -131,7 +131,7 @@ class MQTT:
     :param socket socket_pool: A pool of socket resources available for the given radio.
     :param ssl_context: SSL context for long-lived SSL connections.
     :param bool use_binary_mode: Messages are passed as bytearray instead of string to callbacks.
-    :param int socket_timeout: socket timeout, in seconds
+    :param int socket_timeout: How often to check socket state for read/write/connect operations, in seconds.
 
     """
 

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -6,6 +6,8 @@
 # Modified Work Copyright (c) 2019 Bradley Beach, esp32spi_mqtt
 # Modified Work Copyright (c) 2012-2019 Roger Light and others, Paho MQTT Python
 
+# pylint: disable=too-many-lines
+
 """
 `adafruit_minimqtt`
 ================================================================================

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -131,7 +131,8 @@ class MQTT:
     :param socket socket_pool: A pool of socket resources available for the given radio.
     :param ssl_context: SSL context for long-lived SSL connections.
     :param bool use_binary_mode: Messages are passed as bytearray instead of string to callbacks.
-    :param int socket_timeout: How often to check socket state for read/write/connect operations, in seconds.
+    :param int socket_timeout: How often to check socket state for read/write/connect operations,
+        in seconds.
 
     """
 


### PR DESCRIPTION
This change allows to set socket timeout via the init function, like so:
```python
 mqtt_client = MQTT.MQTT(
        broker=secrets["broker"],
        port=secrets["broker_port"],
        socket_pool=pool,
        ssl_context=ssl.create_default_context(),
        socket_timeout=3,
    )
```
I verified with `strace` that the `poll()` syscall timeout value reflects the `socket_timeout` parameter.