### PR TITLE
avoid endless loop when waiting for data from broker

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -161,7 +161,9 @@ class MQTT:
         self._use_binary_mode = use_binary_mode
 
         if recv_timeout <= socket_timeout:
-            raise MMQTTException("recv_timeout must be strictly greater than socket_timeout")
+            raise MMQTTException(
+                "recv_timeout must be strictly greater than socket_timeout"
+            )
         self._socket_timeout = socket_timeout
         self._recv_timeout = recv_timeout
 

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -159,10 +159,13 @@ class MQTT:
         self._sock = None
         self._backwards_compatible_sock = False
         self._use_binary_mode = use_binary_mode
+
+        if recv_timeout <= socket_timeout:
+            raise MMQTTException("recv_timeout must be strictly greater than socket_timeout")
         self._socket_timeout = socket_timeout
+        self._recv_timeout = recv_timeout
 
         self.keep_alive = keep_alive
-        self._recv_timeout = recv_timeout
         self._user_data = None
         self._is_connected = False
         self._msg_size_lim = MQTT_MSG_SZ_LIM


### PR DESCRIPTION
This change introduces receive timeout so that functions that wait for data from a broker have some upper bound.

Tested on Python 3.9.2 on Raspbian with a remote that accepts any data however does not send anything back (Netcat in plain listen mode).

Thinking of the interaction with the changes in PR #116, it might be prudent to raise `RuntimeError` in the init function if the receive timeout is bigger than the socket timeout.