### PR TITLE
wrap the last exception when reporting repeated connect failures

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -287,8 +287,8 @@ class MQTT:
         if sock is None:
             if last_exception:
                 raise RuntimeError("Repeated socket failures") from last_exception
-            else:
-                raise RuntimeError("Repeated socket failures")
+
+            raise RuntimeError("Repeated socket failures")
 
         self._backwards_compatible_sock = not hasattr(sock, "recv_into")
         return sock


### PR DESCRIPTION
This change allows for better reporting of the `RuntimeError` exception from `connect()` when reporting repeated socket failures. In practice it looks like this (using `logging.exception("Got exception when connecting to MQTT broker")` inside the `except` block):
```
ERROR:root:Got exception when connecting to MQTT broker
Traceback (most recent call last):
  File "/home/pi/shield/env/lib/python3.9/site-packages/adafruit_minimqtt/adafruit_minimqtt.py", line 277, in _get_connect_socket
    sock.connect((connect_host, port))
ConnectionRefusedError: [Errno 111] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/pi/shield/./code.py", line 113, in main
    mqtt_client.connect()
  File "/home/pi/shield/env/lib/python3.9/site-packages/adafruit_minimqtt/adafruit_minimqtt.py", line 459, in connect
    self._sock = self._get_connect_socket(
  File "/home/pi/shield/env/lib/python3.9/site-packages/adafruit_minimqtt/adafruit_minimqtt.py", line 289, in _get_connect_socket
    raise RuntimeError("Repeated socket failures") from last_exception
RuntimeError: Repeated socket failures
```