### PR TITLE
Fetch all messages in loop, non-blocking mode

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -869,7 +869,7 @@ class MQTT:
                 if self.logger is not None:
                     self.logger.debug(
                         f"Loop timed out, message queue not empty after {self._recv_timeout}s"
-                        )
+                    )
                 break
             rcs.append(rc)
 

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -857,10 +857,10 @@ class MQTT:
 
         stamp = time.monotonic()
         self._sock.settimeout(timeout)
-        rcs = []
+        responses = []
         while True:
             rc = self._wait_for_msg()
-            if rc == None: 
+            if rc is None: 
                 break
             if time.monotonic() - stamp > self._recv_timeout:
                 if self.logger is not None:
@@ -868,11 +868,9 @@ class MQTT:
                         f"Loop timed out, message queue not empty after {self._recv_timeout}s"
                         )
                 break
-            else:
-                rcs.append(rc)
+            responses.append(rc)
 
-        return rcs if rcs else None
-
+        return responses if responses else None
 
     def _wait_for_msg(self, timeout=0.1):
         """Reads and processes network events."""

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -892,9 +892,6 @@ class MQTT:
                 if error.errno in (errno.ETIMEDOUT, errno.EAGAIN):
                     # raised by a socket timeout if 0 bytes were present
                     return None
-                if error.errno == errno.EAGAIN:
-                    # there is no data available right now, try again later
-                    return None
                 raise MMQTTException from error
 
         # Block while we parse the rest of the response

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -855,8 +855,17 @@ class MQTT:
             rcs = self.ping()
             return rcs
         self._sock.settimeout(timeout)
-        rc = self._wait_for_msg()
-        return [rc] if rc else None
+
+        responses = [] 
+        while True:
+            rc = self._wait_for_msg()
+            if rc == None: 
+                break
+            else:
+                responses.append(rc)
+
+        return responses if responses else None
+
 
     def _wait_for_msg(self, timeout=0.1):
         """Reads and processes network events."""

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -834,7 +834,7 @@ class MQTT:
                 feed = subscribed_topics.pop()
                 self.subscribe(feed)
 
-    def loop(self, timeout=1):
+    def loop(self, timeout=0):
         """Non-blocking message loop. Use this method to
         check incoming subscription messages.
         Returns response codes of any messages received.

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -862,7 +862,7 @@ class MQTT:
         rcs = []
 
         while True:
-            rc = self._wait_for_msg()
+            rc = self._wait_for_msg(timeout)
             if rc is None:
                 break
             if time.monotonic() - stamp > self._recv_timeout:

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -854,17 +854,24 @@ class MQTT:
                 )
             rcs = self.ping()
             return rcs
-        self._sock.settimeout(timeout)
 
-        responses = [] 
+        stamp = time.monotonic()
+        self._sock.settimeout(timeout)
+        rcs = []
         while True:
             rc = self._wait_for_msg()
             if rc == None: 
                 break
+            if time.monotonic() - stamp > self._recv_timeout:
+                if self.logger is not None:
+                    self.logger.debug(
+                        f"Loop timed out, message queue not empty after {self._recv_timeout}s"
+                        )
+                break
             else:
-                responses.append(rc)
+                rcs.append(rc)
 
-        return responses if responses else None
+        return rcs if rcs else None
 
 
     def _wait_for_msg(self, timeout=0.1):

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -882,6 +882,9 @@ class MQTT:
                 if error.errno == errno.ETIMEDOUT:
                     # raised by a socket timeout if 0 bytes were present
                     return None
+                if error.errno == errno.EAGAIN:
+                    # there is no data available right now, try again later
+                    return None
                 raise MMQTTException from error
 
         # Block while we parse the rest of the response

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -835,6 +835,7 @@ class MQTT:
                 self.subscribe(feed)
 
     def loop(self, timeout=0):
+        # pylint: disable = too-many-return-statements
         """Non-blocking message loop. Use this method to
         check incoming subscription messages.
         Returns response codes of any messages received.
@@ -842,6 +843,7 @@ class MQTT:
         :param int timeout: Socket timeout, in seconds.
 
         """
+
         if self._timestamp == 0:
             self._timestamp = time.monotonic()
         current_time = time.monotonic()
@@ -857,10 +859,11 @@ class MQTT:
 
         stamp = time.monotonic()
         self._sock.settimeout(timeout)
-        responses = []
+        rcs = []
+
         while True:
             rc = self._wait_for_msg()
-            if rc is None: 
+            if rc is None:
                 break
             if time.monotonic() - stamp > self._recv_timeout:
                 if self.logger is not None:
@@ -868,11 +871,13 @@ class MQTT:
                         f"Loop timed out, message queue not empty after {self._recv_timeout}s"
                         )
                 break
-            responses.append(rc)
+            rcs.append(rc)
 
-        return responses if responses else None
+        return rcs if rcs else None
 
     def _wait_for_msg(self, timeout=0.1):
+        # pylint: disable = too-many-return-statements
+
         """Reads and processes network events."""
         # CPython socket module contains a timeout attribute
         if hasattr(self._socket_pool, "timeout"):


### PR DESCRIPTION
First PR, so bear with me!

Basically, I've found issues with callling `loop()` too frequently or too infrequently, that I'm trying to address here.
Calling too frequently (with timeout >0) can lead to a nasty MemoryError. https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/101
Calling too infrequently can cause a build up of messages on the broker. https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/108

I've changed the default timeout to 0 (and added error handling of EAGAIN)
This might be a controversial change - but it means the function is really non-blocking as the comments say it should be. (Perhaps there is a history of why it was set to 1 by default?, I'd be happy keeping it at 1 if it prevents issues for others)

I've also made it call `_wait_for_msg()` in a while loop, similar to how the ping() function works.
I've used the 10s `_recv_timeout` to make sure it can't get stuck in the loop.
This means that all waiting messages are received, not just the next in the queue.
