### PR TITLE
_wait_for_msg(): accept EAGAIN in addition to ETIMEDOUT

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -870,7 +870,7 @@ class MQTT:
             try:
                 res = self._sock_exact_recv(1)
             except OSError as error:
-                if error.errno == errno.ETIMEDOUT:
+                if error.errno in (errno.ETIMEDOUT, errno.EAGAIN):
                     # raised by a socket timeout if 0 bytes were present
                     return None
                 raise MMQTTException from error


### PR DESCRIPTION
You get EAGAIN when passing a timeout value of 0 and there is no data in the buffer.