### PR TITLE
Changed is_connected to return bool while maintaining error checking

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -561,7 +561,7 @@ class MQTT:
 
     def disconnect(self):
         """Disconnects the MiniMQTT client from the MQTT broker."""
-        self.is_connected()
+        self._connected()
         if self.logger is not None:
             self.logger.debug("Sending DISCONNECT packet to broker")
         try:
@@ -582,7 +582,7 @@ class MQTT:
         there is an active network connection.
         Returns response codes of any messages received while waiting for PINGRESP.
         """
-        self.is_connected()
+        self._connected()
         if self.logger is not None:
             self.logger.debug("Sending PINGREQ")
         self._sock.send(MQTT_PINGREQ)
@@ -607,7 +607,7 @@ class MQTT:
         :param int qos: Quality of Service level for the message, defaults to zero.
 
         """
-        self.is_connected()
+        self._connected()
         self._valid_topic(topic)
         if "+" in topic or "#" in topic:
             raise MMQTTException("Publish topic can not contain wildcards.")
@@ -703,7 +703,7 @@ class MQTT:
                         (send at least once), or ``2`` (send exactly once).
 
         """
-        self.is_connected()
+        self._connected()
         topics = None
         if isinstance(topic, tuple):
             topic, qos = topic
@@ -1046,13 +1046,22 @@ class MQTT:
         else:
             raise MMQTTException("QoS must be an integer.")
 
-    def is_connected(self):
+    def _connected(self):
         """Returns MQTT client session status as True if connected, raises
         a `MMQTTException` if `False`.
         """
         if self._sock is None or self._is_connected is False:
             raise MMQTTException("MiniMQTT is not connected.")
         return self._is_connected
+
+    def is_connected(self):
+        """Returns MQTT client session status as True if connected, False
+        if not.
+        """
+        try:
+            return self._connected()
+        except MMQTTException:
+            return False
 
     # Logging
     def enable_logger(self, logger, log_level=20):

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1051,7 +1051,7 @@ class MQTT:
         a `MMQTTException` if `False`.
         """
         if not self.is_connected():
-            raise MQTTException("MiniMQTT is not connected")
+            raise MMQTTException("MiniMQTT is not connected")
 
     def is_connected(self):
         """Returns MQTT client session status as True if connected, False

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1050,18 +1050,14 @@ class MQTT:
         """Returns MQTT client session status as True if connected, raises
         a `MMQTTException` if `False`.
         """
-        if self._sock is None or self._is_connected is False:
-            raise MMQTTException("MiniMQTT is not connected.")
-        return self._is_connected
+        if not self.is_connected():
+            raise MQTTException("MiniMQTT is not connected")
 
     def is_connected(self):
         """Returns MQTT client session status as True if connected, False
         if not.
         """
-        try:
-            return self._connected()
-        except MMQTTException:
-            return False
+        return self._is_connected and self._sock is not None
 
     # Logging
     def enable_logger(self, logger, log_level=20):


### PR DESCRIPTION
closes #109 
Renamed original is_connected method to _connected to maintain internal connection status checking. Created a new is_connected function that returns a bool. This is a breaking change.

This change allows code to be written like:
```
while not mqtt_client.is_connected():
    try:
        mqtt_client.connect()
    except RuntimeError:
        print("Unable to connect. Waiting for 10 seconds before retrying…")
        time.sleep(10)
print("Connected to MQTT broker.")
```

