### PR TITLE
MQTT connect with an empty username should have the proper header

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -482,7 +482,7 @@ class MQTT:
 
         # Set up variable header and remaining_length
         remaining_length = 12 + len(self.client_id.encode("utf-8"))
-        if self._username:
+        if self._username is not None:
             remaining_length += (
                 2
                 + len(self._username.encode("utf-8"))
@@ -532,9 +532,7 @@ class MQTT:
             # [MQTT-3.1.3-11]
             self._send_str(self._lw_topic)
             self._send_str(self._lw_msg)
-        if self._username is None:
-            self._username = None
-        else:
+        if self._username is not None:
             self._send_str(self._username)
             self._send_str(self._password)
         if self.logger is not None:


### PR DESCRIPTION
Connect needs to distinguish None from an empty string when populating and sending CONNECT to the MQTT broker.

Fixes #129

Signed-off-by: Flavio Fernandes <flavio@flaviof.com>