### PR TITLE
make sure to read the whole buffer in _sock_exact_recv()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -965,7 +965,11 @@ class MQTT:
             mv = memoryview(rc)
             recv_len = self._sock.recv_into(rc, bufsize)
             to_read = bufsize - recv_len
-            assert to_read >= 0
+            if to_read < 0:
+                raise MMQTTException(
+                    f"negative number of bytes to read: "
+                    f"{to_read} = {bufsize} - {recv_len}"
+                )
             read_timeout = self.keep_alive
             mv = mv[recv_len:]
             while to_read > 0:

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -963,15 +963,15 @@ class MQTT:
             # CPython/Socketpool Impl.
             rc = bytearray(bufsize)
             mv = memoryview(rc)
-            recv = self._sock.recv_into(rc, bufsize)
-            to_read = bufsize - recv
+            recv_len = self._sock.recv_into(rc, bufsize)
+            to_read = bufsize - recv_len
             assert to_read >= 0
             read_timeout = self.keep_alive
-            mv = mv[recv:]
+            mv = mv[recv_len:]
             while to_read > 0:
-                recv = self._sock.recv_into(mv, to_read)
-                to_read -= recv
-                mv = mv[recv:]
+                recv_len = self._sock.recv_into(mv, to_read)
+                to_read -= recv_len
+                mv = mv[recv_len:]
                 if time.monotonic() - stamp > read_timeout:
                     raise MMQTTException(
                         "Unable to receive {} bytes within {} seconds.".format(

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -974,9 +974,7 @@ class MQTT:
                 mv = mv[recv_len:]
                 if time.monotonic() - stamp > read_timeout:
                     raise MMQTTException(
-                        "Unable to receive {} bytes within {} seconds.".format(
-                            to_read, read_timeout
-                        )
+                        f"Unable to receive {to_read} bytes within {read_timeout} seconds."
                     )
         else:  # ESP32SPI Impl.
             # This will timeout with socket timeout (not keepalive timeout)
@@ -997,9 +995,7 @@ class MQTT:
                 rc += recv
                 if time.monotonic() - stamp > read_timeout:
                     raise MMQTTException(
-                        "Unable to receive {} bytes within {} seconds.".format(
-                            to_read, read_timeout
-                        )
+                        f"Unable to receive {to_read} bytes within {read_timeout} seconds."
                     )
         return rc
 

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -313,35 +313,6 @@ class MQTT:
     def __exit__(self, exception_type, exception_value, traceback):
         self.deinit()
 
-    def _sock_exact_recv(self, bufsize):
-        """Reads _exact_ number of bytes from the connected socket. Will only return
-        string with the exact number of bytes requested.
-
-        The semantics of native socket receive is that it returns no more than the
-        specified number of bytes (i.e. max size). However, it makes no guarantees in
-        terms of the minimum size of the buffer, which could be 1 byte. This is a
-        wrapper for socket recv() to ensure that no less than the expected number of
-        bytes is returned or trigger a timeout exception.
-
-        :param int bufsize: number of bytes to receive
-        """
-        stamp = time.monotonic()
-        rc = self._sock.recv(bufsize)
-        to_read = bufsize - len(rc)
-        assert to_read >= 0
-        read_timeout = self.keep_alive
-        while to_read > 0:
-            recv = self._sock.recv(to_read)
-            to_read -= len(recv)
-            rc += recv
-            if time.monotonic() - stamp > read_timeout:
-                raise MMQTTException(
-                    "Unable to receive {} bytes within {} seconds.".format(
-                        to_read, read_timeout
-                    )
-                )
-        return rc
-
     def deinit(self):
         """De-initializes the MQTT client and disconnects from the mqtt broker."""
         self.disconnect()

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -966,10 +966,7 @@ class MQTT:
             recv_len = self._sock.recv_into(rc, bufsize)
             to_read = bufsize - recv_len
             if to_read < 0:
-                raise MMQTTException(
-                    f"negative number of bytes to read: "
-                    f"{to_read} = {bufsize} - {recv_len}"
-                )
+                raise MMQTTException(f"negative number of bytes to read: {to_read}")
             read_timeout = self.keep_alive
             mv = mv[recv_len:]
             while to_read > 0:


### PR DESCRIPTION
This change addresses the problem of returning incomplete buffer from _sock_exact_recv() in CPython.

Tested with:
```python
#!/usr/bin/env python3

import adafruit_minimqtt.adafruit_minimqtt as MQTT
import socket
import ssl
import logging


def connect_hook(client, user_data, result, code):
    print(f"Connect: {user_data} {result} {code}")


def message_hook(client, topic, message):
    print(f"Message: topic='{topic}' message='{message}'")


broker = "test.mosquitto.org"
port = 1883

mqtt_client = MQTT.MQTT(
    broker=broker,
    port=port,
    socket_pool=socket,
    ssl_context=ssl.create_default_context(),
)


logging.basicConfig()
# mqtt_client.enable_logger(logging, log_level=logging.DEBUG)

# mqtt_client.on_connect = connect_hook
mqtt_client.on_message = message_hook

mqtt_client.connect()
mqtt_client.subscribe('#')

while True:
    try:
        mqtt_client.loop(5)
    except UnicodeDecodeError:
        pass
```

It survived the wild message traffic there for bunch of minutes.