### PR TITLE
add type hints to matcher.py

### DIFF
--- a/adafruit_minimqtt/matcher.py
+++ b/adafruit_minimqtt/matcher.py
@@ -11,6 +11,13 @@ https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/matcher.py
 * Author(s): Yoch (https://github.com/yoch)
 """
 
+try:
+    from typing import Dict, Any
+except ImportError:
+    pass
+
+from collections.abc import Callable, Iterator
+
 
 class MQTTMatcher:
     """Intended to manage topic filters including wildcards.
@@ -27,14 +34,14 @@ class MQTTMatcher:
 
         __slots__ = "children", "content"
 
-        def __init__(self):
-            self.children = {}
+        def __init__(self) -> None:
+            self.children: Dict[str, MQTTMatcher.Node] = {}
             self.content = None
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._root = self.Node()
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Callable[..., Any]) -> None:
         """Add a topic filter :key to the prefix tree
         and associate it to :value"""
         node = self._root
@@ -42,7 +49,7 @@ class MQTTMatcher:
             node = node.children.setdefault(sym, self.Node())
         node.content = value
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Callable[..., Any]:
         """Retrieve the value associated with some topic filter :key"""
         try:
             node = self._root
@@ -54,7 +61,7 @@ class MQTTMatcher:
         except KeyError:
             raise KeyError(key) from None
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: str) -> None:
         """Delete the value associated with some topic filter :key"""
         lst = []
         try:
@@ -71,13 +78,13 @@ class MQTTMatcher:
                     break
                 del parent.children[k]
 
-    def iter_match(self, topic):
+    def iter_match(self, topic: str) -> Iterator[Callable[..., Any]]:
         """Return an iterator on all values associated with filters
         that match the :topic"""
         lst = topic.split("/")
         normal = not topic.startswith("$")
 
-        def rec(node, i=0):
+        def rec(node: MQTTMatcher.Node, i: int = 0) -> Iterator[Callable[..., Any]]:
             if i == len(lst):
                 if node.content is not None:
                     yield node.content

--- a/adafruit_minimqtt/matcher.py
+++ b/adafruit_minimqtt/matcher.py
@@ -12,7 +12,7 @@ https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/matcher.py
 """
 
 try:
-    from typing import Dict, Any
+    from typing import Any, Dict
 except ImportError:
     pass
 

--- a/adafruit_minimqtt/matcher.py
+++ b/adafruit_minimqtt/matcher.py
@@ -12,11 +12,9 @@ https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/matcher.py
 """
 
 try:
-    from typing import Any, Dict
+    from typing import Any, Dict, Callable, Iterator
 except ImportError:
     pass
-
-from collections.abc import Callable, Iterator
 
 
 class MQTTMatcher:

--- a/adafruit_minimqtt/matcher.py
+++ b/adafruit_minimqtt/matcher.py
@@ -12,7 +12,7 @@ https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/matcher.py
 """
 
 try:
-    from typing import Any, Dict, Callable, Iterator
+    from typing import Any, Callable, Dict, Iterator
 except ImportError:
     pass
 

--- a/adafruit_minimqtt/matcher.py
+++ b/adafruit_minimqtt/matcher.py
@@ -12,7 +12,7 @@ https://github.com/eclipse/paho.mqtt.python/blob/master/src/paho/mqtt/matcher.py
 """
 
 try:
-    from typing import Any, Callable, Dict, Iterator
+    from typing import Dict
 except ImportError:
     pass
 
@@ -39,7 +39,7 @@ class MQTTMatcher:
     def __init__(self) -> None:
         self._root = self.Node()
 
-    def __setitem__(self, key: str, value: Callable[..., Any]) -> None:
+    def __setitem__(self, key: str, value) -> None:
         """Add a topic filter :key to the prefix tree
         and associate it to :value"""
         node = self._root
@@ -47,7 +47,7 @@ class MQTTMatcher:
             node = node.children.setdefault(sym, self.Node())
         node.content = value
 
-    def __getitem__(self, key: str) -> Callable[..., Any]:
+    def __getitem__(self, key: str):
         """Retrieve the value associated with some topic filter :key"""
         try:
             node = self._root
@@ -76,13 +76,13 @@ class MQTTMatcher:
                     break
                 del parent.children[k]
 
-    def iter_match(self, topic: str) -> Iterator[Callable[..., Any]]:
+    def iter_match(self, topic: str):
         """Return an iterator on all values associated with filters
         that match the :topic"""
         lst = topic.split("/")
         normal = not topic.startswith("$")
 
-        def rec(node: MQTTMatcher.Node, i: int = 0) -> Iterator[Callable[..., Any]]:
+        def rec(node: MQTTMatcher.Node, i: int = 0):
             if i == len(lst):
                 if node.content is not None:
                     yield node.content


### PR DESCRIPTION
This change approaches #92, specifically for `matcher.py`. After that `mypy` complains only about the function parameters/assignment:
```
$ mypy --strict adafruit_minimqtt/matcher.py 
adafruit_minimqtt/matcher.py:50: error: Incompatible types in assignment (expression has type "Callable[..., Any]", variable has type "None")  [assignment]
adafruit_minimqtt/matcher.py:100: error: Incompatible types in assignment (expression has type "None", variable has type "Callable[..., Any]")  [assignment]
Found 2 errors in 1 file (checked 1 source file)
```

This is my first time adding type hints to Python code and have to say, being used to strongly typed language, that it feels a bit strange - retrofitting type specification that is still limping, e.g. the case of `None` or missing function type parameters. That said, here you go.