### PR TITLE
use correct terminology for enable_logger()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1082,6 +1082,7 @@ class MQTT:
         :param log_level: Numeric value of a logging level, defaults to INFO.
         :param logger_name: name of the logger, defaults to "log".
         :return logger object
+
         """
         self.logger = log_pkg.getLogger(logger_name)
         self.logger.setLevel(log_level)

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1080,10 +1080,12 @@ class MQTT:
 
         :param log_pkg: A Python logging package.
         :param log_level: Numeric value of a logging level, defaults to INFO.
-
+        :return logger object
         """
         self.logger = log_pkg.getLogger("log")
         self.logger.setLevel(log_level)
+
+        return self.logger
 
     def disable_logger(self):
         """Disables logging."""

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1074,15 +1074,16 @@ class MQTT:
         return self._is_connected and self._sock is not None
 
     # Logging
-    def enable_logger(self, log_pkg, log_level=20):
-        """Enables library logging by getting logger named "log" from the specified logging package
+    def enable_logger(self, log_pkg, log_level=20, logger_name="log"):
+        """Enables library logging by getting logger from the specified logging package
         and setting its log level.
 
         :param log_pkg: A Python logging package.
         :param log_level: Numeric value of a logging level, defaults to INFO.
+        :param logger_name: name of the logger, defaults to "log".
         :return logger object
         """
-        self.logger = log_pkg.getLogger("log")
+        self.logger = log_pkg.getLogger(logger_name)
         self.logger.setLevel(log_level)
 
         return self.logger

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1074,14 +1074,15 @@ class MQTT:
         return self._is_connected and self._sock is not None
 
     # Logging
-    def enable_logger(self, logger, log_level=20):
-        """Enables library logging provided a logger object.
+    def enable_logger(self, log_pkg, log_level=20):
+        """Enables library logging by getting logger named "log" from the specified logging package
+        and setting its log level.
 
-        :param logger: A python logger pacakge.
+        :param log_pkg: A Python logging package.
         :param log_level: Numeric value of a logging level, defaults to INFO.
 
         """
-        self.logger = logger.getLogger("log")
+        self.logger = log_pkg.getLogger("log")
         self.logger.setLevel(log_level)
 
     def disable_logger(self):

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1081,6 +1081,7 @@ class MQTT:
         :param log_pkg: A Python logging package.
         :param log_level: Numeric value of a logging level, defaults to INFO.
         :param logger_name: name of the logger, defaults to "log".
+
         :return logger object
 
         """


### PR DESCRIPTION
I noticed that the documentation for `enable_logger()` talks about logger object, while it actually means logging package to create/retrieve the logger. While there I added the possibility to change logger name because by default such generic name was used so it might conflict with a logger created before interacting with `adafruit_minimqtt` (also given how logger creation in `adafruit_logging` works).

While there, I made the function return the logger object, in case someone wants to further change it (e.g. add handlers). I did this because `self.logger` is not preceded with `_` so probably not considered private.