### PR TITLE
_recv_into() is not used anymore

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1040,16 +1040,6 @@ class MQTT:
                 return n
             sh += 7
 
-    def _recv_into(self, buf, size=0):
-        """Backwards-compatible _recv_into implementation."""
-        if self._backwards_compatible_sock:
-            size = len(buf) if size == 0 else size
-            b = self._sock.recv(size)
-            read_size = len(b)
-            buf[:read_size] = b
-            return read_size
-        return self._sock.recv_into(buf, size)
-
     def _sock_exact_recv(self, bufsize):
         """Reads _exact_ number of bytes from the connected socket. Will only return
         string with the exact number of bytes requested.


### PR DESCRIPTION
This change removes `_recv_into()`. It was initially introduced in 8492a58f88465148268546fd58712c41208dee6c, then actually used in 2ae61a459dd2842981a15b63f0e60c0a84646749 and then the call was removed in ea966339379c8081dba94c95bd1f286dfe4dcca1.