### PR TITLE
Settings dot toml

### DIFF
--- a/examples/esp32spi/minimqtt_adafruitio_esp32spi.py
+++ b/examples/esp32spi/minimqtt_adafruitio_esp32spi.py
@@ -1,25 +1,23 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import time
 import board
 import busio
 from digitalio import DigitalInOut
 import neopixel
 from adafruit_esp32spi import adafruit_esp32spi
-from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-### WiFi ###
+# Add settings.toml to your filesystem CIRCUITPY_WIFI_SSID and CIRCUITPY_WIFI_PASSWORD keys
+# with your WiFi credentials. Add your Adafruit IO username and key as well.
+# DO NOT share that file or commit it into Git or other source control.
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+aio_username = os.getenv('aio_username')
+aio_key = os.getenv('aio_key')
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
@@ -46,15 +44,14 @@ status_light = neopixel.NeoPixel(
 # GREEN_LED = PWMOut.PWMOut(esp, 27)
 # BLUE_LED = PWMOut.PWMOut(esp, 25)
 # status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 ### Feeds ###
 
 # Setup a feed named 'photocell' for publishing to a feed
-photocell_feed = secrets["aio_username"] + "/feeds/photocell"
+photocell_feed = aio_username + "/feeds/photocell"
 
 # Setup a feed named 'onoff' for subscribing to changes
-onoff_feed = secrets["aio_username"] + "/feeds/onoff"
+onoff_feed = aio_username + "/feeds/onoff"
 
 ### Code ###
 
@@ -81,7 +78,7 @@ def message(client, topic, message):
 
 # Connect to WiFi
 print("Connecting to WiFi...")
-wifi.connect()
+esp.connect_AP(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
 print("Connected!")
 
 # Initialize MQTT interface with the esp interface
@@ -90,8 +87,8 @@ MQTT.set_socket(socket, esp)
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
-    username=secrets["aio_username"],
-    password=secrets["aio_key"],
+    username=aio_username,
+    password=aio_key,
 )
 
 # Setup the callback methods above

--- a/examples/esp32spi/minimqtt_adafruitio_esp32spi.py
+++ b/examples/esp32spi/minimqtt_adafruitio_esp32spi.py
@@ -16,8 +16,8 @@ import adafruit_minimqtt.adafruit_minimqtt as MQTT
 # with your WiFi credentials. Add your Adafruit IO username and key as well.
 # DO NOT share that file or commit it into Git or other source control.
 
-aio_username = os.getenv('aio_username')
-aio_key = os.getenv('aio_key')
+aio_username = os.getenv("aio_username")
+aio_key = os.getenv("aio_key")
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
@@ -55,6 +55,7 @@ onoff_feed = aio_username + "/feeds/onoff"
 
 ### Code ###
 
+
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name
 def connected(client, userdata, flags, rc):
@@ -78,7 +79,7 @@ def message(client, topic, message):
 
 # Connect to WiFi
 print("Connecting to WiFi...")
-esp.connect_AP(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+esp.connect_AP(os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD"))
 print("Connected!")
 
 # Initialize MQTT interface with the esp interface

--- a/examples/esp32spi/minimqtt_pub_sub_blocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_blocking_esp32spi.py
@@ -87,7 +87,7 @@ MQTT.set_socket(socket, esp)
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
-    broker=os.getenv("broker"), username=aio_username, password=aio_key
+    broker="io.adafruit.com", username=aio_username, password=aio_key
 )
 
 # Setup the callback methods above

--- a/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries 
 # SPDX-License-Identifier: MIT
 
 import os

--- a/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
@@ -1,25 +1,23 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import time
 import board
 import busio
 from digitalio import DigitalInOut
 import neopixel
 from adafruit_esp32spi import adafruit_esp32spi
-from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-### WiFi ###
+# Add settings.toml to your filesystem CIRCUITPY_WIFI_SSID and CIRCUITPY_WIFI_PASSWORD keys
+# with your WiFi credentials. Add your Adafruit IO username and key as well.
+# DO NOT share that file or commit it into Git or other source control.
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+aio_username = os.getenv("aio_username")
+aio_key = os.getenv("aio_key")
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)
@@ -46,12 +44,12 @@ status_light = neopixel.NeoPixel(
 # GREEN_LED = PWMOut.PWMOut(esp, 27)
 # BLUE_LED = PWMOut.PWMOut(esp, 25)
 # status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 ### Adafruit IO Setup ###
 
 # Setup a feed named `testfeed` for publishing.
-default_topic = secrets["user"] + "/feeds/testfeed"
+default_topic = aio_username + "/feeds/testfeed"
+
 
 ### Code ###
 # Define callback methods which are called when events occur
@@ -80,7 +78,7 @@ def message(client, topic, message):
 
 # Connect to WiFi
 print("Connecting to WiFi...")
-wifi.connect()
+esp.connect_AP(os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD"))
 print("Connected!")
 
 # Initialize MQTT interface with the esp interface
@@ -88,7 +86,7 @@ MQTT.set_socket(socket, esp)
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
-    broker=secrets["broker"], username=secrets["user"], password=secrets["pass"]
+    broker=os.getenv("broker"), username=aio_username, password=aio_key
 )
 
 # Setup the callback methods above

--- a/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries 
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
 import os

--- a/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
@@ -57,7 +57,7 @@ default_topic = aio_username + "/feeds/testfeed"
 def connected(client, userdata, flags, rc):
     # This function will be called when the client is connected
     # successfully to the broker.
-    print("Connected to MQTT broker! Listening for topic changes on %s" % default_topic)
+    print(f"Connected to MQTT broker! Listening for topic changes on {default_topic}")
     # Subscribe to all changes on the default_topic feed.
     client.subscribe(default_topic)
 
@@ -73,7 +73,7 @@ def message(client, topic, message):
     :param str topic: The topic of the feed with a new value.
     :param str message: The new value
     """
-    print("New message on topic {0}: {1}".format(topic, message))
+    print(f"New message on topic {topic}: {message}")
 
 
 # Connect to WiFi
@@ -103,7 +103,7 @@ while True:
     mqtt_client.loop()
 
     # Send a new message
-    print("Sending photocell value: %d" % photocell_val)
+    print(f"Sending photocell value: {photocell_val}")
     mqtt_client.publish(default_topic, photocell_val)
     photocell_val += 1
     time.sleep(0.5)

--- a/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
@@ -51,7 +51,6 @@ status_light = neopixel.NeoPixel(
 default_topic = aio_username + "/feeds/testfeed"
 
 
-
 ### Code ###
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name

--- a/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
@@ -86,7 +86,7 @@ MQTT.set_socket(socket, esp)
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
-    broker=os.getenv("broker"), username=aio_username, password=aio_key
+    broker="io.adafruit.com", username=aio_username, password=aio_key
 )
 
 # Setup the callback methods above

--- a/examples/esp32spi/minimqtt_simpletest_esp32spi.py
+++ b/examples/esp32spi/minimqtt_simpletest_esp32spi.py
@@ -57,6 +57,7 @@ mqtt_topic = "test/topic"
 
 ### Code ###
 
+
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name
 def connect(mqtt_client, userdata, flags, rc):

--- a/examples/minimqtt_simpletest.py
+++ b/examples/minimqtt_simpletest.py
@@ -31,7 +31,7 @@ mqtt_topic = "test/topic"
 
 # Adafruit IO-style Topic
 # Use this topic if you'd like to connect to io.adafruit.com
-# mqtt_topic = secrets["aio_username"] + '/feeds/temperature'
+# mqtt_topic = aio_username + '/feeds/temperature'
 
 
 ### Code ###
@@ -77,8 +77,8 @@ pool = socketpool.SocketPool(wifi.radio)
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
     port=8883,
-    username=os.getenv("CIRCUITPY_WIFI_SSID"),
-    password=os.getenv("CIRCUITPY_WIFI_PASSWORD"),
+    username=aio_username,
+    password=aio_key,
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )

--- a/examples/minimqtt_simpletest.py
+++ b/examples/minimqtt_simpletest.py
@@ -16,8 +16,6 @@ import adafruit_minimqtt.adafruit_minimqtt as MQTT
 # or if you need your Adafruit IO key.)
 aio_username = os.getenv("aio_username")
 aio_key = os.getenv("aio_key")
-aio_broker = os.getenv("broker")
-aio_port = os.getenv("port")
 
 print("Connecting to %s" % os.getenv("CIRCUITPY_WIFI_SSID"))
 wifi.radio.connect(
@@ -77,8 +75,8 @@ pool = socketpool.SocketPool(wifi.radio)
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
-    broker=aio_broker,
-    port=aio_port,
+    broker="io.adafruit.com",
+    port=8883,
     username=os.getenv("CIRCUITPY_WIFI_SSID"),
     password=os.getenv("CIRCUITPY_WIFI_PASSWORD"),
     socket_pool=pool,

--- a/examples/minimqtt_simpletest.py
+++ b/examples/minimqtt_simpletest.py
@@ -1,30 +1,29 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import ssl
 import socketpool
 import wifi
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
-# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# Add settings.toml to your filesystem CIRCUITPY_WIFI_SSID and CIRCUITPY_WIFI_PASSWORD keys
+# with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
-# pylint: disable=no-name-in-module,wrong-import-order
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
 
-# Set your Adafruit IO Username and Key in secrets.py
+# Set your Adafruit IO Username and Key in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-aio_username = secrets["aio_username"]
-aio_key = secrets["aio_key"]
+aio_username = os.getenv("aio_username")
+aio_key = os.getenv("aio_key")
+aio_broker = os.getenv("broker")
+aio_port = os.getenv("port")
 
-print("Connecting to %s" % secrets["ssid"])
-wifi.radio.connect(secrets["ssid"], secrets["password"])
-print("Connected to %s!" % secrets["ssid"])
+print("Connecting to %s" % os.getenv("CIRCUITPY_WIFI_SSID"))
+wifi.radio.connect(
+    os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD")
+)
+print("Connected to %s!" % os.getenv("CIRCUITPY_WIFI_SSID"))
 
 ### Topic Setup ###
 
@@ -35,6 +34,7 @@ mqtt_topic = "test/topic"
 # Adafruit IO-style Topic
 # Use this topic if you'd like to connect to io.adafruit.com
 # mqtt_topic = secrets["aio_username"] + '/feeds/temperature'
+
 
 ### Code ###
 # Define callback methods which are called when events occur
@@ -77,10 +77,10 @@ pool = socketpool.SocketPool(wifi.radio)
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
-    broker=secrets["broker"],
-    port=secrets["port"],
-    username=secrets["aio_username"],
-    password=secrets["aio_key"],
+    broker=aio_broker,
+    port=aio_port,
+    username=os.getenv("CIRCUITPY_WIFI_SSID"),
+    password=os.getenv("CIRCUITPY_WIFI_PASSWORD"),
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )

--- a/examples/native_networking/minimqtt_adafruitio_native_networking.py
+++ b/examples/native_networking/minimqtt_adafruitio_native_networking.py
@@ -18,11 +18,11 @@ import adafruit_minimqtt.adafruit_minimqtt as MQTT
 aio_username = os.getenv("aio_username")
 aio_key = os.getenv("aio_key")
 
-print("Connecting to %s" % os.getenv("CIRCUITPY_WIFI_SSID"))
+print(f"Connecting to {os.getenv('CIRCUITPY_WIFI_SSID')}")
 wifi.radio.connect(
     os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD")
 )
-print("Connected to %s!" % os.getenv("CIRCUITPY_WIFI_SSID"))
+print(f"Connected to {os.getenv('CIRCUITPY_WIFI_SSID')}!")
 ### Feeds ###
 
 # Setup a feed named 'photocell' for publishing to a feed
@@ -39,7 +39,7 @@ onoff_feed = aio_username + "/feeds/onoff"
 def connected(client, userdata, flags, rc):
     # This function will be called when the client is connected
     # successfully to the broker.
-    print("Connected to Adafruit IO! Listening for topic changes on %s" % onoff_feed)
+    print(f"Connected to Adafruit IO! Listening for topic changes on {onoff_feed}")
     # Subscribe to all changes on the onoff_feed.
     client.subscribe(onoff_feed)
 
@@ -52,7 +52,7 @@ def disconnected(client, userdata, rc):
 def message(client, topic, message):
     # This method is called when a topic the client is subscribed to
     # has a new message.
-    print("New message on topic {0}: {1}".format(topic, message))
+    print(f"New message on topic {topic}: {message}")
 
 
 # Create a socket pool
@@ -61,9 +61,9 @@ pool = socketpool.SocketPool(wifi.radio)
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
-    port=8883,
-    username=os.getenv("CIRCUITPY_WIFI_SSID"),
-    password=os.getenv("CIRCUITPY_WIFI_PASSWORD"),
+    port=1883,
+    username=aio_username,
+    password=aio_key,
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )
@@ -83,7 +83,7 @@ while True:
     mqtt_client.loop()
 
     # Send a new message
-    print("Sending photocell value: %d..." % photocell_val)
+    print(f"Sending photocell value: {photocell_val}...")
     mqtt_client.publish(photocell_feed, photocell_val)
     print("Sent!")
     photocell_val += 1

--- a/examples/native_networking/minimqtt_adafruitio_native_networking.py
+++ b/examples/native_networking/minimqtt_adafruitio_native_networking.py
@@ -17,7 +17,6 @@ import adafruit_minimqtt.adafruit_minimqtt as MQTT
 # or if you need your Adafruit IO key.)
 aio_username = os.getenv("aio_username")
 aio_key = os.getenv("aio_key")
-aio_port = os.getenv("port")
 
 print("Connecting to %s" % os.getenv("CIRCUITPY_WIFI_SSID"))
 wifi.radio.connect(
@@ -62,9 +61,9 @@ pool = socketpool.SocketPool(wifi.radio)
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
-    port=aio_port,
-    username=aio_username,
-    password=aio_key,
+    port=8883,
+    username=os.getenv("CIRCUITPY_WIFI_SSID"),
+    password=os.getenv("CIRCUITPY_WIFI_PASSWORD"),
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )

--- a/examples/native_networking/minimqtt_adafruitio_native_networking.py
+++ b/examples/native_networking/minimqtt_adafruitio_native_networking.py
@@ -1,38 +1,34 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import time
 import ssl
 import socketpool
 import wifi
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
-# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# Add settings.toml to your filesystem CIRCUITPY_WIFI_SSID and CIRCUITPY_WIFI_PASSWORD keys
+# with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
-# pylint: disable=no-name-in-module,wrong-import-order
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
 
-# Set your Adafruit IO Username and Key in secrets.py
+# Set your Adafruit IO Username, Key and Port in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-aio_username = secrets["aio_username"]
-aio_key = secrets["aio_key"]
+aio_username = os.getenv('aio_username')
+aio_key = os.getenv('aio_key')
+aio_port = os.getenv('port')
 
-print("Connecting to %s" % secrets["ssid"])
-wifi.radio.connect(secrets["ssid"], secrets["password"])
-print("Connected to %s!" % secrets["ssid"])
+print("Connecting to %s" % os.getenv('CIRCUITPY_WIFI_SSID'))
+wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
+print("Connected to %s!" % os.getenv('CIRCUITPY_WIFI_SSID'))
 ### Feeds ###
 
 # Setup a feed named 'photocell' for publishing to a feed
-photocell_feed = secrets["aio_username"] + "/feeds/photocell"
+photocell_feed = aio_username + "/feeds/photocell"
 
 # Setup a feed named 'onoff' for subscribing to changes
-onoff_feed = secrets["aio_username"] + "/feeds/onoff"
+onoff_feed = aio_username + "/feeds/onoff"
 
 ### Code ###
 
@@ -63,9 +59,9 @@ pool = socketpool.SocketPool(wifi.radio)
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
     broker="io.adafruit.com",
-    port=secrets["port"],
-    username=secrets["aio_username"],
-    password=secrets["aio_key"],
+    port=aio_port,
+    username=aio_username,
+    password=aio_key,
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )

--- a/examples/native_networking/minimqtt_adafruitio_native_networking.py
+++ b/examples/native_networking/minimqtt_adafruitio_native_networking.py
@@ -15,13 +15,15 @@ import adafruit_minimqtt.adafruit_minimqtt as MQTT
 # Set your Adafruit IO Username, Key and Port in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-aio_username = os.getenv('aio_username')
-aio_key = os.getenv('aio_key')
-aio_port = os.getenv('port')
+aio_username = os.getenv("aio_username")
+aio_key = os.getenv("aio_key")
+aio_port = os.getenv("port")
 
-print("Connecting to %s" % os.getenv('CIRCUITPY_WIFI_SSID'))
-wifi.radio.connect(os.getenv('CIRCUITPY_WIFI_SSID'), os.getenv('CIRCUITPY_WIFI_PASSWORD'))
-print("Connected to %s!" % os.getenv('CIRCUITPY_WIFI_SSID'))
+print("Connecting to %s" % os.getenv("CIRCUITPY_WIFI_SSID"))
+wifi.radio.connect(
+    os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD")
+)
+print("Connected to %s!" % os.getenv("CIRCUITPY_WIFI_SSID"))
 ### Feeds ###
 
 # Setup a feed named 'photocell' for publishing to a feed
@@ -31,6 +33,7 @@ photocell_feed = aio_username + "/feeds/photocell"
 onoff_feed = aio_username + "/feeds/onoff"
 
 ### Code ###
+
 
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name

--- a/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries 
 # SPDX-License-Identifier: MIT
 
 import os

--- a/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
@@ -36,7 +36,7 @@ default_topic = aio_username + "/feeds/testfeed"
 def connected(client, userdata, flags, rc):
     # This function will be called when the client is connected
     # successfully to the broker.
-    print("Connected to MQTT broker! Listening for topic changes on %s" % default_topic)
+    print(f"Connected to MQTT broker! Listening for topic changes on {default_topic}")
     # Subscribe to all changes on the default_topic feed.
     client.subscribe(default_topic)
 
@@ -52,7 +52,7 @@ def message(client, topic, message):
     :param str topic: The topic of the feed with a new value.
     :param str message: The new value
     """
-    print("New message on topic {0}: {1}".format(topic, message))
+    print(f"New message on topic {topic}: {message}")
 
 
 # Create a socket pool

--- a/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries 
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
 import os

--- a/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
@@ -1,36 +1,34 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import time
 import ssl
 import socketpool
 import wifi
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
-# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# Add settings.toml to your filesystem CIRCUITPY_WIFI_SSID and CIRCUITPY_WIFI_PASSWORD keys
+# with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
-# pylint: disable=no-name-in-module,wrong-import-order
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
 
-# Set your Adafruit IO Username and Key in secrets.py
+# Set your Adafruit IO Username, Key and Port in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-aio_username = secrets["aio_username"]
-aio_key = secrets["aio_key"]
+aio_username = os.getenv("aio_username")
+aio_key = os.getenv("aio_key")
 
-print("Connecting to %s" % secrets["ssid"])
-wifi.radio.connect(secrets["ssid"], secrets["password"])
-print("Connected to %s!" % secrets["ssid"])
+print("Connecting to %s" % os.getenv("CIRCUITPY_WIFI_SSID"))
+wifi.radio.connect(
+    os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD")
+)
+print("Connected to %s!" % os.getenv("CIRCUITPY_WIFI_SSID"))
 
 ### Adafruit IO Setup ###
 
 # Setup a feed named `testfeed` for publishing.
-default_topic = secrets["aio_username"] + "/feeds/testfeed"
+default_topic = aio_username + "/feeds/testfeed"
+
 
 ### Code ###
 # Define callback methods which are called when events occur
@@ -62,10 +60,10 @@ pool = socketpool.SocketPool(wifi.radio)
 
 # Set up a MiniMQTT Client
 mqtt_client = MQTT.MQTT(
-    broker=secrets["broker"],
-    port=secrets["port"],
-    username=secrets["aio_username"],
-    password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    port=1883,
+    username=aio_username,
+    password=aio_key,
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )

--- a/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
@@ -30,7 +30,6 @@ print("Connected to %s!" % os.getenv("CIRCUITPY_WIFI_SSID"))
 default_topic = aio_username + "/feeds/testfeed"
 
 
-
 ### Code ###
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name

--- a/examples/native_networking/minimqtt_pub_sub_blocking_topic_callbacks_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_topic_callbacks_native_networking.py
@@ -1,33 +1,31 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import time
 import ssl
 import socketpool
 import wifi
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
-# Add a secrets.py to your filesystem that has a dictionary called secrets with "ssid" and
-# "password" keys with your WiFi credentials. DO NOT share that file or commit it into Git or other
+# Add settings.toml to your filesystem CIRCUITPY_WIFI_SSID and CIRCUITPY_WIFI_PASSWORD keys
+# with your WiFi credentials. DO NOT share that file or commit it into Git or other
 # source control.
-# pylint: disable=no-name-in-module,wrong-import-order
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
 
-# Set your Adafruit IO Username and Key in secrets.py
+# Set your Adafruit IO Username, Key and Port in settings.toml
 # (visit io.adafruit.com if you need to create an account,
 # or if you need your Adafruit IO key.)
-aio_username = secrets["aio_username"]
-aio_key = secrets["aio_key"]
+aio_username = os.getenv("aio_username")
+aio_key = os.getenv("aio_key")
 
-print("Connecting to %s" % secrets["ssid"])
-wifi.radio.connect(secrets["ssid"], secrets["password"])
-print("Connected to %s!" % secrets["ssid"])
+print("Connecting to %s" % os.getenv("CIRCUITPY_WIFI_SSID"))
+wifi.radio.connect(
+    os.getenv("CIRCUITPY_WIFI_SSID"), os.getenv("CIRCUITPY_WIFI_PASSWORD")
+)
+print("Connected to %s!" % os.getenv("CIRCUITPY_WIFI_SSID"))
 
 ### Code ###
+
 
 # Define callback methods which are called when events occur
 # pylint: disable=unused-argument, redefined-outer-name
@@ -56,7 +54,7 @@ def on_battery_msg(client, topic, message):
     # Method called when device/batteryLife has a new value
     print("Battery level: {}v".format(message))
 
-    # client.remove_topic_callback(secrets["aio_username"] + "/feeds/device.batterylevel")
+    # client.remove_topic_callback(aio_username + "/feeds/device.batterylevel")
 
 
 def on_message(client, topic, message):
@@ -69,10 +67,10 @@ pool = socketpool.SocketPool(wifi.radio)
 
 # Set up a MiniMQTT Client
 client = MQTT.MQTT(
-    broker=secrets["broker"],
-    port=secrets["port"],
-    username=secrets["aio_username"],
-    password=secrets["aio_key"],
+    broker="io.adafruit.com",
+    port=1883,
+    username=aio_username,
+    password=aio_key,
     socket_pool=pool,
     ssl_context=ssl.create_default_context(),
 )
@@ -83,16 +81,14 @@ client.on_disconnect = disconnected
 client.on_subscribe = subscribe
 client.on_unsubscribe = unsubscribe
 client.on_message = on_message
-client.add_topic_callback(
-    secrets["aio_username"] + "/feeds/device.batterylevel", on_battery_msg
-)
+client.add_topic_callback(aio_username + "/feeds/device.batterylevel", on_battery_msg)
 
 # Connect the client to the MQTT broker.
 print("Connecting to MQTT broker...")
 client.connect()
 
 # Subscribe to all notifications on the device group
-client.subscribe(secrets["aio_username"] + "/groups/device", 1)
+client.subscribe(aio_username + "/groups/device", 1)
 
 # Start a blocking message loop...
 # NOTE: NO code below this loop will execute


### PR DESCRIPTION
hihi @brentru - I updated the examples that are in the MiniMQTT guide to use settings.toml. Had to change up the WiFi connection method for ESP32SPI since adafruit_esp32spi_wifimanager assumes secrets is being used. Tested native networking with a QT Py ESP32-S2 and ESP32SPI with a Metro M7.

if you are good with how these are formatted I can update the other examples as well.

