### PR TITLE
recv_into fix for esp32spi socket implementation

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1122,7 +1122,7 @@ class MQTT:
             if recv_len == 0:
                 self.logger.debug("_sock_exact_recv timeout")
                 # If no bytes are waiting, raise an OSError for good measure.
-                # Some implementations of recv_into do this on their own (like CPython), 
+                # Some implementations of recv_into do this on their own (like CPython),
                 # but we should be prepared if one doesn't (looking at you esp23spi...)
                 raise OSError(errno.ETIMEDOUT)
             to_read = bufsize - recv_len

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1119,6 +1119,14 @@ class MQTT:
             rc = bytearray(bufsize)
             mv = memoryview(rc)
             recv_len = self._sock.recv_into(rc, bufsize)
+            
+            if recv_len == 0:
+                self.logger.debug("_sock_exact_recv timeout")
+                # If no bytes are waiting, raise an OSError for good measure.
+                # Some implementations of recv_into do this on their own (like CPython), 
+                # but we should be prepared if one doesn't (looking at you esp23spi...)
+                raise OSError(errno.ETIMEDOUT)
+
             to_read = bufsize - recv_len
             if to_read < 0:
                 raise MMQTTException(f"negative number of bytes to read: {to_read}")

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1119,14 +1119,12 @@ class MQTT:
             rc = bytearray(bufsize)
             mv = memoryview(rc)
             recv_len = self._sock.recv_into(rc, bufsize)
-            
             if recv_len == 0:
                 self.logger.debug("_sock_exact_recv timeout")
                 # If no bytes are waiting, raise an OSError for good measure.
                 # Some implementations of recv_into do this on their own (like CPython), 
                 # but we should be prepared if one doesn't (looking at you esp23spi...)
                 raise OSError(errno.ETIMEDOUT)
-
             to_read = bufsize - recv_len
             if to_read < 0:
                 raise MMQTTException(f"negative number of bytes to read: {to_read}")


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/148 and https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/165

The esp32spi socket implementations of `recv` and `recv_into` do not raise an OSError if the read times out, deviating from the behavior in CPython. In the past we accounted for this by checking whether anything was read when calling `recv`, if not, raise an OSError ourselves. However, in https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/commit/c334c8157dddc06f67b85b9c299b49d0b29f3031 we started to utilize `recv_into` rather than `recv`, if it was available. The new version does not have the "raise OSError ourselves if nothing was read"-workaround, because it was assumed that esp32spi wouldn't have `recv_into` and the old version would be used. 

Ideally, this would be fixed in esp32spi for both functions. However, I think they'd be hesitant to except such a radical change - it'd likely break projects relying on the old implementation. Hence I believe we should take it upon ourselves to fix it.

Maybe it's also appropriate to entirely drop support for socket implementations that lack `recv_into`. Our alternative implementation utilizing `recv` is labled "esp32 fix", but esp32spi sockets have had support for `recv_into` for more than a year. I did not include this change in my PR, but I think it should be considered. 