### PR TITLE
loop() timeout parameter should be absolute

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1008,9 +1008,7 @@ class MQTT:
             if rc is not None:
                 rcs.append(rc)
             if time.monotonic() - stamp > timeout:
-                self.logger.debug(
-                    f"Loop timed out, message queue empty after {timeout} seconds"
-                )
+                self.logger.debug(f"Loop timed out after {timeout} seconds")
                 break
 
         return rcs if rcs else None

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -983,7 +983,7 @@ class MQTT:
         """Non-blocking message loop. Use this method to check for incoming messages.
         Returns list of response codes of any messages received or None.
 
-        :param float timeout: timeout to wait for a message, in seconds.
+        :param float timeout: return after this timeout, in seconds.
 
         """
 

--- a/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
+++ b/examples/esp32spi/minimqtt_pub_sub_nonblocking_esp32spi.py
@@ -109,4 +109,4 @@ while True:
     print("Sending photocell value: %d" % photocell_val)
     mqtt_client.publish(default_topic, photocell_val)
     photocell_val += 1
-    time.sleep(0.5)
+    time.sleep(3)


### PR DESCRIPTION
This changes the way how loop() deals with the timeout parameter. I think the original idea was to wait for the timeout and then return what was received in the mean time, regardless of whether anything was actually received. This means that the loop() will always return after the timeout, i.e. not earlier (assuming no fatal error happened).

Inspired by https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/68#issue-805498443 and the discussion in PR #168.