### PR TITLE
check is_connected in loop()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -986,7 +986,7 @@ class MQTT:
         :param float timeout: return after this timeout, in seconds.
 
         """
-
+        self._connected()
         self.logger.debug(f"waiting for messages for {timeout} seconds")
         if self._timestamp == 0:
             self._timestamp = time.monotonic()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -49,7 +49,6 @@ class Loop(TestCase):
         ) as wait_for_msg_mock, patch.object(
             mqtt_client, "is_connected"
         ) as is_connected_mock:
-
             wait_for_msg_mock.side_effect = self.fake_wait_for_msg
             is_connected_mock.side_effect = lambda: True
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -44,8 +44,11 @@ class Loop(TestCase):
             ssl_context=ssl.create_default_context(),
         )
 
-        with patch.object(mqtt_client, "_wait_for_msg") as wait_for_msg_mock, \
-                patch.object(mqtt_client, "is_connected") as is_connected_mock:
+        with patch.object(
+            mqtt_client, "_wait_for_msg"
+        ) as wait_for_msg_mock, patch.object(
+            mqtt_client, "is_connected"
+        ) as is_connected_mock:
 
             wait_for_msg_mock.side_effect = self.fake_wait_for_msg
             is_connected_mock.side_effect = lambda: True
@@ -65,6 +68,22 @@ class Loop(TestCase):
             for ret_code in rcs:
                 assert ret_code == expected_rc
                 expected_rc += 1
+
+    def test_loop_is_connected(self):
+        """
+        loop() should throw MMQTTException if not connected
+        """
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+        )
+
+        with self.assertRaises(MQTT.MMQTTException) as context:
+            mqtt_client.loop(timeout=1)
+
+        assert "not connected" in str(context.exception)
 
 
 if __name__ == "__main__":

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -44,8 +44,11 @@ class Loop(TestCase):
             ssl_context=ssl.create_default_context(),
         )
 
-        with patch.object(mqtt_client, "_wait_for_msg") as mock_method:
-            mock_method.side_effect = self.fake_wait_for_msg
+        with patch.object(mqtt_client, "_wait_for_msg") as wait_for_msg_mock, \
+                patch.object(mqtt_client, "is_connected") as is_connected_mock:
+
+            wait_for_msg_mock.side_effect = self.fake_wait_for_msg
+            is_connected_mock.side_effect = lambda: True
 
             time_before = time.monotonic()
             timeout = random.randint(3, 8)
@@ -53,7 +56,7 @@ class Loop(TestCase):
             time_after = time.monotonic()
 
             assert time_after - time_before >= timeout
-            mock_method.assert_called()
+            wait_for_msg_mock.assert_called()
 
             # Check the return value.
             assert rcs is not None


### PR DESCRIPTION
[Someone hit a None-deref](https://forums.adafruit.com/viewtopic.php?t=203980) when calling `loop()` without calling `connect()` first. This change checks the connected status in loop() and raises exception if not connected.