### PR TITLE
add on_message callback with user data

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -267,6 +267,7 @@ class MQTT:
 
         # Default topic callback methods
         self._on_message = None
+        self.on_message_user_data = None
         self.on_connect = None
         self.on_disconnect = None
         self.on_publish = None
@@ -451,8 +452,11 @@ class MQTT:
                 callback(self, topic, message)  # on_msg with callback
                 matched = True
 
-        if not matched and self.on_message:  # regular on_message
-            self.on_message(self, topic, message)
+        if not matched:  # regular on_message
+            if self.on_message:
+                self.on_message(self, topic, message)
+            if self.on_message_user_data:
+                self.on_message_user_data(self, self._user_data, topic, message)
 
     def username_pw_set(self, username: str, password: Optional[str] = None) -> None:
         """Set client's username and an optional password.

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -427,7 +427,9 @@ class MQTT:
         :param function callback_method: The callback method with user data.
         """
         if mqtt_topic is None or callback_method is None or self._user_data is None:
-            raise ValueError("MQTT topic, callback method and user data must both be defined.")
+            raise ValueError(
+                "MQTT topic, callback method and user data must both be defined."
+            )
         self._on_message_filtered_user_data[mqtt_topic] = callback_method
 
     def remove_topic_callback(self, mqtt_topic: str) -> None:

--- a/tests/test_handle_on_message.py
+++ b/tests/test_handle_on_message.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2023 Vladimír Kotal
+#
+# SPDX-License-Identifier: Unlicense
+
+"""_handle_on_message() tests"""
+
+import socket
+import ssl
+from unittest import TestCase, main
+from unittest.mock import MagicMock
+
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
+
+
+class OnMessage(TestCase):
+    """unit tests for _handle_on_message()"""
+
+    def test_handle_on_message(self) -> None:
+        """
+        test that _handle_on_message() calls both regular message handlers if set.
+        """
+
+        host = "172.40.0.3"
+        port = 1883
+
+        user_data = "foo"
+        mqtt_client = MQTT.MQTT(
+            broker=host,
+            port=port,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+            user_data=user_data,
+        )
+
+        mqtt_client.on_message_user_data = MagicMock()
+        mqtt_client.on_message = MagicMock()
+
+        topic = "devices/foo/bar"
+        message = '{"foo": "bar"}'
+        mqtt_client._handle_on_message(topic, message)
+        mqtt_client.on_message.assert_called_with(mqtt_client, topic, message)
+        mqtt_client.on_message_user_data.assert_called_with(mqtt_client, user_data, topic, message)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_handle_on_message.py
+++ b/tests/test_handle_on_message.py
@@ -24,7 +24,7 @@ class OnMessage(TestCase):
         host = "172.40.0.3"
         port = 1883
 
-        user_data = "foo"
+        user_data = "regular"
         mqtt_client = MQTT.MQTT(
             broker=host,
             port=port,
@@ -44,6 +44,33 @@ class OnMessage(TestCase):
         mqtt_client.on_message_user_data.assert_called_with(
             mqtt_client, user_data, topic, message
         )
+
+    # pylint: disable=no-self-use
+    def test_handle_on_message_filtered(self) -> None:
+        """
+        test that _handle_on_message() calls the callback for filtered topic if set.
+        """
+
+        host = "172.40.0.3"
+        port = 1883
+
+        user_data = "filtered"
+        mqtt_client = MQTT.MQTT(
+            broker=host,
+            port=port,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+            user_data=user_data,
+        )
+
+        topic = "devices/foo/bar"
+        mock_callback = MagicMock()
+        mqtt_client.add_topic_callback_user_data(topic, mock_callback)
+
+        message = '{"foo": "bar"}'
+        # pylint: disable=protected-access
+        mqtt_client._handle_on_message(topic, message)
+        mock_callback.assert_called_with(mqtt_client, user_data, topic, message)
 
 
 if __name__ == "__main__":

--- a/tests/test_handle_on_message.py
+++ b/tests/test_handle_on_message.py
@@ -39,7 +39,9 @@ class OnMessage(TestCase):
         message = '{"foo": "bar"}'
         mqtt_client._handle_on_message(topic, message)
         mqtt_client.on_message.assert_called_with(mqtt_client, topic, message)
-        mqtt_client.on_message_user_data.assert_called_with(mqtt_client, user_data, topic, message)
+        mqtt_client.on_message_user_data.assert_called_with(
+            mqtt_client, user_data, topic, message
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_handle_on_message.py
+++ b/tests/test_handle_on_message.py
@@ -15,6 +15,7 @@ import adafruit_minimqtt.adafruit_minimqtt as MQTT
 class OnMessage(TestCase):
     """unit tests for _handle_on_message()"""
 
+    # pylint: disable=no-self-use
     def test_handle_on_message(self) -> None:
         """
         test that _handle_on_message() calls both regular message handlers if set.
@@ -37,6 +38,7 @@ class OnMessage(TestCase):
 
         topic = "devices/foo/bar"
         message = '{"foo": "bar"}'
+        # pylint: disable=protected-access
         mqtt_client._handle_on_message(topic, message)
         mqtt_client.on_message.assert_called_with(mqtt_client, topic, message)
         mqtt_client.on_message_user_data.assert_called_with(


### PR DESCRIPTION
This change introduces "on_message" callbacks with `user_data`. I chose to take a conservative approach in order not to break existing code, hence the new callback methods.