### PR TITLE
encode/decode remaining length properly for {,UN}SUBSCRIBE/SUBACK

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -890,7 +890,7 @@ class MQTT:
                         f"invalid message received as response to SUBSCRIBE: {hex(op)}"
                     )
 
-    def unsubscribe(self, topic: str) -> None:
+    def unsubscribe(self, topic: Optional[Union[str, list]]) -> None:
         """Unsubscribes from a MQTT topic.
 
         :param str|list topic: Unique MQTT topic identifier string or list.

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -869,7 +869,7 @@ class MQTT:
             qos_byte = q.to_bytes(1, "big")
             packet += topic_size + t.encode() + qos_byte
         for t, q in topics:
-            self.logger.debug("SUBSCRIBING to topic %s with QoS %d", t, q)
+            self.logger.debug(f"SUBSCRIBING to topic {t} with QoS {q}")
         self.logger.debug(f"packet: {packet}")
         self._sock.send(packet)
         stamp = self.get_monotonic_time()

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -800,7 +800,7 @@ class MQTT:
                             f"No data received from broker for {self._recv_timeout} seconds."
                         )
 
-    def subscribe(self, topic: str, qos: int = 0) -> None:
+    def subscribe(self, topic: Optional[Union[tuple, str, list]], qos: int = 0) -> None:
         """Subscribes to a topic on the MQTT Broker.
         This method can subscribe to one topic or multiple topics.
 

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -765,16 +765,7 @@ class MQTT:
             pub_hdr_var.append(self._pid >> 8)
             pub_hdr_var.append(self._pid & 0xFF)
 
-        # Calculate remaining length [2.2.3]
-        if remaining_length > 0x7F:
-            while remaining_length > 0:
-                encoded_byte = remaining_length % 0x80
-                remaining_length = remaining_length // 0x80
-                if remaining_length > 0:
-                    encoded_byte |= 0x80
-                pub_hdr_fixed.append(encoded_byte)
-        else:
-            pub_hdr_fixed.append(remaining_length)
+        self.encode_remaining_length(pub_hdr_fixed, remaining_length)
 
         self.logger.debug(
             "Sending PUBLISH\nTopic: %s\nMsg: %s\

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -880,11 +880,15 @@ class MQTT:
                         if self.on_subscribe is not None:
                             self.on_subscribe(self, self.user_data, t, q)
                         self._subscribed_topics.append(t)
+
                     return
 
-                raise MMQTTException(
-                    f"invalid message received as response to SUBSCRIBE: {hex(op)}"
-                )
+                if op != MQTT_PUBLISH:
+                    # [3.8.4] The Server is permitted to start sending PUBLISH packets
+                    # matching the Subscription before the Server sends the SUBACK Packet.
+                    raise MMQTTException(
+                        f"invalid message received as response to SUBSCRIBE: {hex(op)}"
+                    )
 
     def unsubscribe(self, topic: str) -> None:
         """Unsubscribes from a MQTT topic.

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -856,15 +856,15 @@ class MQTT:
         self.logger.debug(f"Variable Header: {var_header}")
         self._sock.send(var_header)
         # attaching topic and QOS level to the packet
-        packet = bytes()
+        payload = bytes()
         for t, q in topics:
             topic_size = len(t.encode("utf-8")).to_bytes(2, "big")
             qos_byte = q.to_bytes(1, "big")
-            packet += topic_size + t.encode() + qos_byte
+            payload += topic_size + t.encode() + qos_byte
         for t, q in topics:
             self.logger.debug(f"SUBSCRIBING to topic {t} with QoS {q}")
-        self.logger.debug(f"packet: {packet}")
-        self._sock.send(packet)
+        self.logger.debug(f"payload: {payload}")
+        self._sock.send(payload)
         stamp = self.get_monotonic_time()
         while True:
             op = self._wait_for_msg()

--- a/tests/mocket.py
+++ b/tests/mocket.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2023 Vladimír Kotal
+#
+# SPDX-License-Identifier: Unlicense
+
+"""fake socket class for protocol level testing"""
+
+from unittest import mock
+
+
+class Mocket:
+    """
+    Mock Socket tailored for MiniMQTT testing. Records sent data,
+    hands out pre-recorded reply.
+
+    Inspired by the Mocket class from Adafruit_CircuitPython_Requests
+    """
+
+    def __init__(self, to_send):
+        self._to_send = to_send
+
+        self.sent = bytearray()
+
+        self.timeout = mock.Mock()
+        self.connect = mock.Mock()
+        self.close = mock.Mock()
+
+    def send(self, bytes_to_send):
+        """merely record the bytes. return the length of this bytearray."""
+        self.sent.extend(bytes_to_send)
+        return len(bytes_to_send)
+
+    # MiniMQTT checks for the presence of "recv_into" and switches behavior based on that.
+    def recv_into(self, retbuf, bufsize):
+        """return data from internal buffer"""
+        size = min(bufsize, len(self._to_send))
+        if size == 0:
+            return size
+        chop = self._to_send[0:size]
+        retbuf[0:] = chop
+        self._to_send = self._to_send[size:]
+        return size

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -1,0 +1,148 @@
+# SPDX-FileCopyrightText: 2023 Vladimír Kotal
+#
+# SPDX-License-Identifier: Unlicense
+
+"""subscribe tests"""
+
+import logging
+import ssl
+from unittest import mock
+
+import pytest
+
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
+
+
+class Mocket:
+    """
+    Mock Socket tailored for MiniMQTT testing. Records sent data,
+    hands out pre-recorded reply.
+
+    Inspired by the Mocket class from Adafruit_CircuitPython_Requests
+    """
+
+    def __init__(self, to_send):
+        self._to_send = to_send
+
+        self.sent = bytearray()
+
+        self.timeout = mock.Mock()
+        self.connect = mock.Mock()
+        self.close = mock.Mock()
+
+    def send(self, bytes_to_send):
+        """merely record the bytes. return the length of this bytearray."""
+        self.sent.extend(bytes_to_send)
+        return len(bytes_to_send)
+
+    # MiniMQTT checks for the presence of "recv_into" and switches behavior based on that.
+    def recv_into(self, retbuf, bufsize):
+        """return data from internal buffer"""
+        size = min(bufsize, len(self._to_send))
+        if size == 0:
+            return size
+        chop = self._to_send[0:size]
+        retbuf[0:] = chop
+        self._to_send = self._to_send[size:]
+        return size
+
+
+# pylint: disable=unused-argument
+def handle_subscribe(client, user_data, topic, qos):
+    """
+    Record topics into user data.
+    """
+    assert topic
+    assert qos == 0
+
+    user_data.append(topic)
+
+
+# The MQTT packet contents below were captured using Mosquitto client+server.
+testdata = [
+    # short topic with remaining length encoded as single byte
+    (
+        "foo/bar",
+        bytearray([0x90, 0x03, 0x00, 0x01, 0x00]),
+        bytearray(
+            [
+                0x82,  # fixed header
+                0x0C,  # remaining length
+                0x00,
+                0x01,  # message ID
+                0x00,
+                0x07,  # topic length
+                0x66,  # topic
+                0x6F,
+                0x6F,
+                0x2F,
+                0x62,
+                0x61,
+                0x72,
+                0x00,  # QoS
+            ]
+        ),
+    ),
+    # remaining length is encoded as 2 bytes due to long topic name.
+    (
+        "f" + "o" * 257,
+        bytearray([0x90, 0x03, 0x00, 0x01, 0x00]),
+        bytearray(
+            [
+                0x82,  # fixed header
+                0x87,  # remaining length
+                0x02,
+                0x00,  # message ID
+                0x01,
+                0x01,  # topic length
+                0x02,
+                0x66,  # topic
+            ]
+            + [0x6F] * 257
+            + [0x00]  # QoS
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "topic,to_send,exp_recv", testdata, ids=["short_topic", "long_topic"]
+)
+def test_subscribe(topic, to_send, exp_recv) -> None:
+    """
+    Protocol level testing of SUBSCRIBE and SUBACK packet handling.
+
+    Nothing will travel over the wire, it is all fake.
+    """
+    logging.basicConfig()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
+
+    host = "localhost"
+    port = 1883
+
+    subscribed_topics = []
+    mqtt_client = MQTT.MQTT(
+        broker=host,
+        port=port,
+        ssl_context=ssl.create_default_context(),
+        connect_retries=1,
+        user_data=subscribed_topics,
+    )
+
+    mqtt_client.on_subscribe = handle_subscribe
+
+    # patch is_connected() to avoid CONNECT/CONNACK handling.
+    mqtt_client.is_connected = lambda: True
+    mocket = Mocket(to_send)
+    # pylint: disable=protected-access
+    mqtt_client._sock = mocket
+
+    mqtt_client.logger = logger
+
+    # pylint: disable=logging-fstring-interpolation
+    logger.info(f"subscribing to {topic}")
+    mqtt_client.subscribe(topic)
+
+    assert topic in subscribed_topics
+    assert mocket.sent == exp_recv

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -29,7 +29,7 @@ testdata = [
     # short topic with remaining length encoded as single byte
     (
         "foo/bar",
-        bytearray([0x90, 0x03, 0x00, 0x01, 0x00]),
+        bytearray([0x90, 0x03, 0x00, 0x01, 0x00]),  # SUBACK
         bytearray(
             [
                 0x82,  # fixed header
@@ -52,7 +52,7 @@ testdata = [
     # remaining length is encoded as 2 bytes due to long topic name.
     (
         "f" + "o" * 257,
-        bytearray([0x90, 0x03, 0x00, 0x01, 0x00]),
+        bytearray([0x90, 0x03, 0x00, 0x01, 0x00]),  # SUBACK
         bytearray(
             [
                 0x82,  # fixed header
@@ -68,11 +68,58 @@ testdata = [
             + [0x00]  # QoS
         ),
     ),
+    # SUBSCRIBE responded to by PUBLISH followed by SUBACK
+    (
+        "foo/bar",
+        bytearray(
+            [
+                0x30,  # PUBLISH
+                0x0C,
+                0x00,
+                0x07,
+                0x66,
+                0x6F,
+                0x6F,
+                0x2F,
+                0x62,
+                0x61,
+                0x72,
+                0x66,
+                0x6F,
+                0x6F,
+                0x90,  # SUBACK
+                0x03,
+                0x00,
+                0x01,
+                0x00,
+            ]
+        ),
+        bytearray(
+            [
+                0x82,  # fixed header
+                0x0C,  # remaining length
+                0x00,
+                0x01,  # message ID
+                0x00,
+                0x07,  # topic length
+                0x66,  # topic
+                0x6F,
+                0x6F,
+                0x2F,
+                0x62,
+                0x61,
+                0x72,
+                0x00,  # QoS
+            ]
+        ),
+    ),
 ]
 
 
 @pytest.mark.parametrize(
-    "topic,to_send,exp_recv", testdata, ids=["short_topic", "long_topic"]
+    "topic,to_send,exp_recv",
+    testdata,
+    ids=["short_topic", "long_topic", "publish_first"],
 )
 def test_subscribe(topic, to_send, exp_recv) -> None:
     """

--- a/tests/test_subscribe.py
+++ b/tests/test_subscribe.py
@@ -6,45 +6,11 @@
 
 import logging
 import ssl
-from unittest import mock
 
 import pytest
+from mocket import Mocket
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
-
-
-class Mocket:
-    """
-    Mock Socket tailored for MiniMQTT testing. Records sent data,
-    hands out pre-recorded reply.
-
-    Inspired by the Mocket class from Adafruit_CircuitPython_Requests
-    """
-
-    def __init__(self, to_send):
-        self._to_send = to_send
-
-        self.sent = bytearray()
-
-        self.timeout = mock.Mock()
-        self.connect = mock.Mock()
-        self.close = mock.Mock()
-
-    def send(self, bytes_to_send):
-        """merely record the bytes. return the length of this bytearray."""
-        self.sent.extend(bytes_to_send)
-        return len(bytes_to_send)
-
-    # MiniMQTT checks for the presence of "recv_into" and switches behavior based on that.
-    def recv_into(self, retbuf, bufsize):
-        """return data from internal buffer"""
-        size = min(bufsize, len(self._to_send))
-        if size == 0:
-            return size
-        chop = self._to_send[0:size]
-        retbuf[0:] = chop
-        self._to_send = self._to_send[size:]
-        return size
 
 
 # pylint: disable=unused-argument

--- a/tests/test_unsubscribe.py
+++ b/tests/test_unsubscribe.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2023 Vladimír Kotal
+#
+# SPDX-License-Identifier: Unlicense
+
+"""unsubscribe tests"""
+
+import logging
+import ssl
+
+import pytest
+from mocket import Mocket
+
+import adafruit_minimqtt.adafruit_minimqtt as MQTT
+
+
+# pylint: disable=unused-argument
+def handle_unsubscribe(client, user_data, topic, pid):
+    """
+    Record topics into user data.
+    """
+    assert topic
+
+    user_data.append(topic)
+
+
+# The MQTT packet contents below were captured using Mosquitto client+server.
+# These are verbatim, except message ID that was changed from 2 to 1 since in the real world
+# capture the UNSUBSCRIBE packet followed the SUBSCRIBE packet.
+testdata = [
+    # short topic with remaining length encoded as single byte
+    (
+        "foo/bar",
+        bytearray([0xB0, 0x02, 0x00, 0x01]),
+        bytearray(
+            [
+                0xA2,  # fixed header
+                0x0B,  # remaining length
+                0x00,  # message ID
+                0x01,
+                0x00,  # topic length
+                0x07,
+                0x66,  # topic
+                0x6F,
+                0x6F,
+                0x2F,
+                0x62,
+                0x61,
+                0x72,
+            ]
+        ),
+    ),
+    # remaining length is encoded as 2 bytes due to long topic name.
+    (
+        "f" + "o" * 257,
+        bytearray([0xB0, 0x02, 0x00, 0x01]),
+        bytearray(
+            [
+                0xA2,  # fixed header
+                0x86,  # remaining length
+                0x02,
+                0x00,  # message ID
+                0x01,
+                0x01,  # topic length
+                0x02,
+                0x66,  # topic
+            ]
+            + [0x6F] * 257
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "topic,to_send,exp_recv", testdata, ids=["short_topic", "long_topic"]
+)
+def test_unsubscribe(topic, to_send, exp_recv) -> None:
+    """
+    Protocol level testing of UNSUBSCRIBE and UNSUBACK packet handling.
+
+    Nothing will travel over the wire, it is all fake.
+    Also, the topics are not subscribed into.
+    """
+    logging.basicConfig()
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
+
+    host = "localhost"
+    port = 1883
+
+    unsubscribed_topics = []
+    mqtt_client = MQTT.MQTT(
+        broker=host,
+        port=port,
+        ssl_context=ssl.create_default_context(),
+        connect_retries=1,
+        user_data=unsubscribed_topics,
+    )
+
+    mqtt_client.on_unsubscribe = handle_unsubscribe
+
+    # patch is_connected() to avoid CONNECT/CONNACK handling.
+    mqtt_client.is_connected = lambda: True
+    mocket = Mocket(to_send)
+    # pylint: disable=protected-access
+    mqtt_client._sock = mocket
+
+    mqtt_client.logger = logger
+
+    # pylint: disable=protected-access
+    mqtt_client._subscribed_topics = [topic]
+
+    # pylint: disable=logging-fstring-interpolation
+    logger.info(f"unsubscribing from {topic}")
+    mqtt_client.unsubscribe(topic)
+
+    assert topic in unsubscribed_topics
+    assert mocket.sent == exp_recv


### PR DESCRIPTION
This change fixes remaining length encoding for SUBSCRIBE packets, allowing subscribe to pass for remaning length bigger than 127. Tested on CPython with:
```python
#!/usr/bin/env python3

import json
import socket
import ssl
import sys

import adafruit_minimqtt.adafruit_minimqtt as MQTT

import logging


def main():
    logging.basicConfig()
    logger = logging.getLogger(__name__)
    logger.setLevel(logging.DEBUG)

    logger.info("Creating MQTT instance")

    broker = "172.40.0.3"
    port = 1883
    mqtt_client = MQTT.MQTT(
        broker=broker,
        port=port,
        socket_pool=socket,
        ssl_context=ssl.create_default_context(),
        connect_retries=3,
    )

    mqtt_client.enable_logger(logging, log_level=logging.DEBUG)

    logger.info("Connecting to MQTT broker")
    mqtt_client.connect()

    topics = [("broken/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/pat/toolong",0)]
    logger.info(f"subscribing to {topics}")
    mqtt_client.subscribe(topics)

    i = 0
    while True:
        logger.info(f"iteration {i}")
        ret = mqtt_client.loop(timeout=3)
        if ret is not None:
             logger.info(f"got {ret}")
        i = i + 1


if __name__ == "__main__":
    main()

```
which produces the following output:
```
INFO:__main__:Creating MQTT instance
INFO:__main__:Connecting to MQTT broker
DEBUG:log:Attempting to connect to MQTT broker (attempt #0)
DEBUG:log:Attempting to establish MQTT connection...
INFO:log:Establishing an INSECURE connection to 172.40.0.3:1883
DEBUG:log:Sending CONNECT to broker...
DEBUG:log:Fixed Header: bytearray(b'\x10\x14\x00')
DEBUG:log:Variable Header: bytearray(b'\x04MQTT\x04\x02\x00<')
DEBUG:log:Receiving CONNACK packet from broker
DEBUG:log:Got message type: 0x20
DEBUG:log:Resetting reconnect backoff
INFO:__main__:subscribing to [('broken/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/pat/toolong', 0)]
DEBUG:log:Sending SUBSCRIBE to broker...
DEBUG:log:Fixed Header: bytearray(b'\x82\x80\x01')
DEBUG:log:Variable Header: b'\x00\x01'
DEBUG:log:SUBSCRIBING to topic broken/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/pat/toolong with QoS 0
DEBUG:log:packet: b'\x00{broken/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/path/pat/toolong\x00'
DEBUG:log:Got message type: 0x90
INFO:__main__:iteration 0
DEBUG:log:waiting for messages for 3 seconds
DEBUG:log:Loop timed out after 3 seconds
INFO:__main__:iteration 1
DEBUG:log:waiting for messages for 3 seconds
...
```