### PR TITLE
don't raise an exception on PUBLISH messages while waiting for SUBACK

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -885,6 +885,9 @@ class MQTT:
                         self._subscribed_topics.append(t)
                     return
 
+                if op == MQTT_PUBLISH:
+                    continue
+
                 raise MMQTTException(
                     f"invalid message received as response to SUBSCRIBE: {hex(op)}"
                 )


### PR DESCRIPTION
Addresses [issue 192](https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/192)