### PR TITLE
Simplify socket exceptions

### DIFF
--- a/tests/test_port_ssl.py
+++ b/tests/test_port_ssl.py
@@ -20,7 +20,7 @@ class PortSslSetup(TestCase):
     def test_default_port(self) -> None:
         """verify default port value and that TLS is not used"""
         host = "127.0.0.1"
-        port = 1883
+        expected_port = 1883
 
         with patch.object(socket.socket, "connect") as connect_mock:
             ssl_context = ssl.create_default_context()
@@ -31,14 +31,15 @@ class PortSslSetup(TestCase):
                 connect_retries=1,
             )
 
+            connect_mock.side_effect = OSError
             ssl_mock = Mock()
             ssl_context.wrap_socket = ssl_mock
 
             with self.assertRaises(MQTT.MMQTTException):
-                expected_port = port
                 mqtt_client.connect()
 
             ssl_mock.assert_not_called()
+
             connect_mock.assert_called()
             # Assuming the repeated calls will have the same arguments.
             connect_mock.assert_has_calls([call((host, expected_port))])


### PR DESCRIPTION
The purpose of this PR is to simplify socket exceptions, so the move to [ConnectionManager](https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager) is smother.

Currently when getting a socket, an `OSError` is not treated as a `TemporaryError` and thus the retry is delayed. As far as I can tell, there is no benefit to delaying the next try here and it will cause `ConnectionManager` to be overly complex.

This treats `OSError` like any other error, and thus no custom handling will be needed in `ConnectionManager`.

If there is something I am missing, please let me know.