### PR TITLE
Add `timeout` value.

### DIFF
--- a/examples/native_networking/minimqtt_adafruitio_native_networking.py
+++ b/examples/native_networking/minimqtt_adafruitio_native_networking.py
@@ -90,7 +90,7 @@ mqtt_client.connect()
 photocell_val = 0
 while True:
     # Poll the message queue
-    mqtt_client.loop()
+    mqtt_client.loop(timeout=1)
 
     # Send a new message
     print(f"Sending photocell value: {photocell_val}...")

--- a/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_native_networking.py
@@ -92,7 +92,7 @@ mqtt_client.connect()
 # NOTE: Network reconnection is handled within this loop
 while True:
     try:
-        mqtt_client.loop()
+        mqtt_client.loop(timeout=1)
     except (ValueError, RuntimeError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()

--- a/examples/native_networking/minimqtt_pub_sub_blocking_topic_callbacks_native_networking.py
+++ b/examples/native_networking/minimqtt_pub_sub_blocking_topic_callbacks_native_networking.py
@@ -104,7 +104,7 @@ client.subscribe(aio_username + "/groups/device", 1)
 # NOTE: NO code below this loop will execute
 while True:
     try:
-        client.loop()
+        client.loop(timeout=1)
     except (ValueError, RuntimeError) as e:
         print("Failed to get data, retrying\n", e)
         wifi.reset()


### PR DESCRIPTION
Add `timeout` value to avoid `MMQTTException: loop timeout (0) must be bigger than socket timeout (1))` error.