### PR TITLE
pystack and other errors

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -435,7 +435,10 @@ class MQTT:
                 self._reset_reconnect_backoff()
                 return ret
             except (MemoryError, OSError, RuntimeError) as e:
+                if isinstance(e, RuntimeError) and e.args == ("pystack exhausted",):
+                    raise
                 self.logger.warning(f"Socket error when connecting: {e}")
+                last_exception = e
                 backoff = False
             except MMQTTException as e:
                 self._close_socket()


### PR DESCRIPTION
This PR fixes a few things (although the changes are tiny):

fixes #215
`After pystack limit reached, MQTT service continues retry until timeout`
Added a catch for the `RuntimeError: pystack exhaustet` to stop retrying

This also fixes https://github.com/adafruit/Adafruit_CircuitPython_AWS_IOT/issues/23
`AWS_IOT_ERROR ('Error Connection to AWS IoT: ', MQTTException('Repeated connect failures',))`

fixes #214
`generic timeout error when 'is_ssl' param not set for an mqtt service that requires it`
This is fixed also by https://github.com/adafruit/circuitpython/pull/9266
Together these provide better errors so the use knows what's happening