### PR TITLE
Resolve race condition for UNSUBACK

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -865,6 +865,8 @@ class MQTT:
                         self._subscribed_topics.remove(t)
                     return
                 if op != MQTT_PUBLISH:
+                    # [3.10.4] The Server may continue to deliver existing messages buffered for delivery
+                    # to the client prior to sending the UNSUBACK Packet.
                     raise MMQTTException(
                         f"invalid message received as response to UNSUBSCRIBE: {hex(op)}"
                     )

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -865,8 +865,8 @@ class MQTT:
                         self._subscribed_topics.remove(t)
                     return
                 if op != MQTT_PUBLISH:
-                    # [3.10.4] The Server may continue to deliver existing messages buffered for delivery
-                    # to the client prior to sending the UNSUBACK Packet.
+                    # [3.10.4] The Server may continue to deliver existing messages buffered
+                    # for delivery to the client prior to sending the UNSUBACK Packet.
                     raise MMQTTException(
                         f"invalid message received as response to UNSUBSCRIBE: {hex(op)}"
                     )


### PR DESCRIPTION
When attempting to unsubscribe from a topic it was possible to receive the following error:

`Traceback (most recent call last):
  File "code.py", line 79, in <module>
  File "/lib/adafruit_minimqtt/adafruit_minimqtt.py", line 869, in unsubscribe
MMQTTException: ('invalid message received as response to UNSUBSCRIBE: 0x30', None)
`

This is due to the unsubscribe function assuming the next packet received will either be the UNSUBACK or an error code, rather than accounting for possible PUBLISH packets coming from the MQTT broker that may have already been in flight. Looking at some packet captures taken from the broker side its possible to get this error before the broker even receives the UNSUB request.

This fix essentially sets the unsubscribe function to match the existing behavior in the subscribe function, which ignores publish messages while waiting for the SUBACK.

Additionally I added named constant values for the SUBACK and UNSUBACK opcodes, replacing the 'magic number' values for comparing returned opcodes to increase clarity.