### PR TITLE
allow to specify session_id for connect()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -432,7 +432,7 @@ class MQTT:
                     host=host,
                     port=port,
                     keep_alive=keep_alive,
-                    session_id=session_id
+                    session_id=session_id,
                 )
                 self._reset_reconnect_backoff()
                 return ret

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -399,6 +399,7 @@ class MQTT:
         host: Optional[str] = None,
         port: Optional[int] = None,
         keep_alive: Optional[int] = None,
+        session_id: Optional[str] = None,
     ) -> int:
         """Initiates connection with the MQTT Broker. Will perform exponential back-off
         on connect failures.
@@ -408,7 +409,8 @@ class MQTT:
         :param int port: Network port of the remote broker.
         :param int keep_alive: Maximum period allowed for communication
             within single connection attempt, in seconds.
-
+        :param str session_id: unique session ID,
+            used for multiple simultaneous connections to the same host
         """
 
         last_exception = None
@@ -430,6 +432,7 @@ class MQTT:
                     host=host,
                     port=port,
                     keep_alive=keep_alive,
+                    session_id=session_id
                 )
                 self._reset_reconnect_backoff()
                 return ret
@@ -467,6 +470,7 @@ class MQTT:
         host: Optional[str] = None,
         port: Optional[int] = None,
         keep_alive: Optional[int] = None,
+        session_id: Optional[str] = None,
     ) -> int:
         """Initiates connection with the MQTT Broker.
 
@@ -474,6 +478,8 @@ class MQTT:
         :param str host: Hostname or IP address of the remote broker.
         :param int port: Network port of the remote broker.
         :param int keep_alive: Maximum period allowed for communication, in seconds.
+        :param str session_id: unique session ID,
+            used for multiple simultaneous connections to the same host
 
         """
         if host:
@@ -496,6 +502,7 @@ class MQTT:
             self.broker,
             self.port,
             proto="mqtt:",
+            session_id=session_id,
             timeout=self._socket_timeout,
             is_ssl=self._is_ssl,
             ssl_context=self._ssl_context,

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -393,7 +393,7 @@ class MQTT:
         if password is not None:
             self._password = password
 
-    def connect(
+    def connect(  # noqa: PLR0913, too many arguments in function definition
         self,
         clean_session: bool = True,
         host: Optional[str] = None,
@@ -464,7 +464,7 @@ class MQTT:
             raise MMQTTException(exc_msg) from last_exception
         raise MMQTTException(exc_msg)
 
-    def _connect(  # noqa: PLR0912, PLR0915, Too many branches, Too many statements
+    def _connect(  # noqa: PLR0912, PLR0913, PLR0915, Too many branches, Too many arguments, Too many statements
         self,
         clean_session: bool = True,
         host: Optional[str] = None,


### PR DESCRIPTION
The `ConnectionManager` used by MiniMQTT disallows connecting to the same host/port combination multiple times. Sometimes it is actually handy to be able to create multiple connections, e.g. to test a MQTT broker implementation. This change allows for that by propagating the `session_id` parameter from `connect()` to the `ConnectionManager`.

Tested with CPython and a MQTT broker (called `femtomqtt`) running on localhost:

```python
#!/usr/bin/env python3

import logging
import socket
import ssl
import sys
import signal

import adafruit_minimqtt.adafruit_minimqtt as MQTT


def main(session_id):
    logging.basicConfig(format='%(asctime)s.%(msecs)03d %(levelname)s %(module)s - %(funcName)s: %(message)s',
                        datefmt='%H:%M:%S')
    logger = logging.getLogger(__name__)
    logger.setLevel(logging.DEBUG)

    host = "localhost"
    port = 1883
    mqtt_client = MQTT.MQTT(
        broker=host,
        port=port,
        socket_pool=socket,
        ssl_context=ssl.create_default_context(),
        connect_retries=1,
    )

    mqtt_client.logger = logger

    for i in range(2):
        logger.debug(f"connect #{i} with session_id = {session_id}")
        if session_id:
            session_id += f"{i}"
        mqtt_client.connect(session_id=session_id)

    signal.pause()


if __name__ == "__main__":
    session_id = None
    if len(sys.argv) > 1:
        session_id = sys.argv[1]
    try:
        main(session_id)
    except KeyboardInterrupt:
       pass
```
With no arguments the program ends with:
```
20:32:18.085 DEBUG session_id - main: connect #0 with session_id = foo
20:32:18.085 DEBUG adafruit_minimqtt - connect: Attempting to connect to MQTT broker (attempt #0)
20:32:18.085 DEBUG adafruit_minimqtt - _connect: Attempting to establish MQTT connection...
20:32:18.086 DEBUG adafruit_minimqtt - _connect: Sending CONNECT to broker...
20:32:18.086 DEBUG adafruit_minimqtt - _connect: Fixed Header: bytearray(b'\x10\x14')
20:32:18.086 DEBUG adafruit_minimqtt - _connect: Variable Header: bytearray(b'\x00\x04MQTT\x04\x02\x00<')
20:32:18.087 DEBUG adafruit_minimqtt - _connect: Receiving CONNACK packet from broker
20:32:18.087 DEBUG adafruit_minimqtt - _wait_for_msg: Got message type: 0x20 pkt: 0x20
20:32:18.087 DEBUG adafruit_minimqtt - _reset_reconnect_backoff: Resetting reconnect backoff
20:32:18.087 DEBUG session_id - main: connect #1 with session_id = foo0
20:32:18.087 DEBUG adafruit_minimqtt - connect: Attempting to connect to MQTT broker (attempt #0)
20:32:18.087 DEBUG adafruit_minimqtt - _connect: Attempting to establish MQTT connection...
20:32:18.087 DEBUG adafruit_minimqtt - _close_socket: Closing socket
20:32:18.087 WARNING adafruit_minimqtt - connect: Socket error when connecting: Socket already connected to mqtt://localhost:1883
Traceback (most recent call last):
  File "/home/vkotal/Adafruit_CircuitPython_MiniMQTT/adafruit_minimqtt/adafruit_minimqtt.py", line 430, in connect
    ret = self._connect(
  File "/home/vkotal/Adafruit_CircuitPython_MiniMQTT/adafruit_minimqtt/adafruit_minimqtt.py", line 501, in _connect
    self._sock = self._connection_manager.get_socket(
  File "/home/vkotal/Adafruit_CircuitPython_MiniMQTT/venv/lib/python3.10/site-packages/adafruit_connection_manager.py", line 311, in get_socket
    raise RuntimeError(f"Socket already connected to {proto}//{host}:{port}")
RuntimeError: Socket already connected to mqtt://localhost:1883

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/vkotal/Adafruit_CircuitPython_MiniMQTT/./session_id.py", line 45, in <module>
    main(session_id)
  File "/home/vkotal/Adafruit_CircuitPython_MiniMQTT/./session_id.py", line 35, in main
    mqtt_client.connect()
  File "/home/vkotal/Adafruit_CircuitPython_MiniMQTT/adafruit_minimqtt/adafruit_minimqtt.py", line 464, in connect
    raise MMQTTException(exc_msg) from last_exception
adafruit_minimqtt.adafruit_minimqtt.MMQTTException: ('Connect failure', None)
```
with any argument 2 connections are created (verified with `netstat`):
```
20:33:18.508 DEBUG session_id - main: connect #0 with session_id = foo
20:33:18.508 DEBUG adafruit_minimqtt - connect: Attempting to connect to MQTT broker (attempt #0)
20:33:18.508 DEBUG adafruit_minimqtt - _connect: Attempting to establish MQTT connection...
20:33:18.509 DEBUG adafruit_minimqtt - _connect: Sending CONNECT to broker...
20:33:18.509 DEBUG adafruit_minimqtt - _connect: Fixed Header: bytearray(b'\x10\x14')
20:33:18.509 DEBUG adafruit_minimqtt - _connect: Variable Header: bytearray(b'\x00\x04MQTT\x04\x02\x00<')
20:33:18.509 DEBUG adafruit_minimqtt - _connect: Receiving CONNACK packet from broker
20:33:18.509 DEBUG adafruit_minimqtt - _wait_for_msg: Got message type: 0x20 pkt: 0x20
20:33:18.509 DEBUG adafruit_minimqtt - _reset_reconnect_backoff: Resetting reconnect backoff
20:33:18.509 DEBUG session_id - main: connect #1 with session_id = foo0
20:33:18.509 DEBUG adafruit_minimqtt - connect: Attempting to connect to MQTT broker (attempt #0)
20:33:18.509 DEBUG adafruit_minimqtt - _connect: Attempting to establish MQTT connection...
20:33:18.509 DEBUG adafruit_minimqtt - _connect: Sending CONNECT to broker...
20:33:18.509 DEBUG adafruit_minimqtt - _connect: Fixed Header: bytearray(b'\x10\x14')
20:33:18.510 DEBUG adafruit_minimqtt - _connect: Variable Header: bytearray(b'\x00\x04MQTT\x04\x02\x00<')
20:33:18.510 DEBUG adafruit_minimqtt - _connect: Receiving CONNACK packet from broker
20:33:18.510 DEBUG adafruit_minimqtt - _wait_for_msg: Got message type: 0x20 pkt: 0x20
20:33:18.510 DEBUG adafruit_minimqtt - _reset_reconnect_backoff: Resetting reconnect backoff
```