### PR TITLE
timout 1 instead of 0

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -931,7 +931,7 @@ class MQTT:
         if timeout < self._socket_timeout:
             raise MMQTTException(
                 f"loop timeout ({timeout}) must be >= "
-                + f"than socket timeout ({self._socket_timeout}))"
+                + f"socket timeout ({self._socket_timeout}))"
             )
 
         self._connected()

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -921,7 +921,7 @@ class MQTT:
 
         return ret
 
-    def loop(self, timeout: float = 0) -> Optional[list[int]]:
+    def loop(self, timeout: float = 1.0) -> Optional[list[int]]:
         """Non-blocking message loop. Use this method to check for incoming messages.
         Returns list of packet types of any messages received or None.
 

--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -930,7 +930,7 @@ class MQTT:
         """
         if timeout < self._socket_timeout:
             raise MMQTTException(
-                f"loop timeout ({timeout}) must be bigger "
+                f"loop timeout ({timeout}) must be >= "
                 + f"than socket timeout ({self._socket_timeout}))"
             )
 


### PR DESCRIPTION
@ladyada 
Resolves: #227 

Solution discussed with @brentru on discord. I did try changing the cpython examples to use 0, but that still leads to the exception being raised about being shorter than the socket timeout, so I've left them alone in this PR.