### PR TITLE
Update minimqtt_adafruitio_native_networking.py

### DIFF
--- a/examples/native_networking/minimqtt_adafruitio_native_networking.py
+++ b/examples/native_networking/minimqtt_adafruitio_native_networking.py
@@ -26,10 +26,10 @@ print(f"Connected to {os.getenv('CIRCUITPY_WIFI_SSID')}!")
 ### Feeds ###
 
 # Setup a feed named 'photocell' for publishing to a feed
-photocell_feed = aio_username + "/feeds/photocell"
+photocell_feed = "photocell"
 
 # Setup a feed named 'onoff' for subscribing to changes
-onoff_feed = aio_username + "/feeds/onoff"
+onoff_feed = "onoff"
 
 ### Code ###
 


### PR DESCRIPTION
The newer versions of the miniMQTT library seem to break when  you put the whole key for the feed in there. `foo/feed/group.feed` no longer works ( [this breaks it](https://github.com/adafruit/Adafruit_CircuitPython_AdafruitIO/blob/ece3e396ccb5504558f6b11423a96d06a6dfb5c9/adafruit_io/adafruit_io.py#L43-L54) ), but instead it needs to be just `group.feed`.