### PR TITLE
handle partial socket send()'s

### DIFF
--- a/tests/test_recv_timeout.py
+++ b/tests/test_recv_timeout.py
@@ -46,7 +46,7 @@ class RecvTimeout(TestCase):
                     mqtt_client.ping()
 
                 now = time.monotonic()
-                assert recv_timeout <= (now - start) <= (keep_alive + 0.1)
+                assert recv_timeout <= (now - start) <= (keep_alive + 0.2)
 
 
 if __name__ == "__main__":

--- a/tests/test_recv_timeout.py
+++ b/tests/test_recv_timeout.py
@@ -9,6 +9,8 @@ import time
 from unittest import TestCase, main
 from unittest.mock import Mock
 
+from mocket import Mocket
+
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
 
@@ -34,7 +36,7 @@ class RecvTimeout(TestCase):
                 )
 
                 # Create a mock socket that will accept anything and return nothing.
-                socket_mock = Mock()
+                socket_mock = Mocket(b"")
                 socket_mock.recv_into = Mock(side_effect=side_effect)
                 mqtt_client._sock = socket_mock
 
@@ -42,10 +44,6 @@ class RecvTimeout(TestCase):
                 start = time.monotonic()
                 with self.assertRaises(MQTT.MMQTTException):
                     mqtt_client.ping()
-
-                # Verify the mock interactions.
-                socket_mock.send.assert_called_once()
-                socket_mock.recv_into.assert_called()
 
                 now = time.monotonic()
                 assert recv_timeout <= (now - start) <= (keep_alive + 0.1)


### PR DESCRIPTION
- Fixes #230.

The library was using `socket.send()` directly, but not checking the return value to see if all the bytes were sent. So for larger packets, a partial send would go unnoticed. Added `_send_bytes()`, which calls `send()` until all bytes are sent, and also handles `EAGAIN`. I could have used `socket.sendall()`, but it doesn't handle EAGAIN.

I tested by sending 2900-byte packets to a no-history Adafruit IO test feed. @manchicken, who submitted #230, also tested.