### PR TITLE
fix EAGAIN reference in _send_bytes()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -475,7 +475,7 @@ class MQTT:
             try:
                 bytes_sent += self._sock.send(view[bytes_sent:])
             except OSError as exc:
-                if exc.errno == EAGAIN:
+                if exc.errno == errno.EAGAIN:
                     continue
                 raise
 


### PR DESCRIPTION
https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/commit/75f384545d7590c0d92594cc450c97238d27874b added code for `_send_bytes()` with incomplete reference to `EAGAIN`. This change fixes that.