### PR TITLE
Handle ESP32SPI Socket.send(), which does not return a byte count

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -473,7 +473,11 @@ class MQTT:
         view = memoryview(buffer)
         while bytes_sent < bytes_to_send:
             try:
-                bytes_sent += self._sock.send(view[bytes_sent:])
+                sent_now = self._sock.send(view[bytes_sent:])
+                # Some versions of `Socket.send()` do not return the number of bytes sent.
+                if not isinstance(sent_now, int):
+                    return
+                bytes_sent += sent_now
             except OSError as exc:
                 if exc.errno == errno.EAGAIN:
                     continue


### PR DESCRIPTION
- Fixes #234.

#231 assumed `Socket.send()` was going to return an int, as it does in CPython. The ESP32SPI version does not :frowning_face: . Thanks @baldengineer and @axelmagnus for testing.