### PR TITLE
no need to check zero byte returned from recv_into()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1015,7 +1015,7 @@ class MQTT:
                     return None
                 raise MMQTTException from error
 
-        if res in [None, b"", b"\x00"]:
+        if res in [None, b""]:
             # If we get here, it means that there is nothing to be received
             return None
         pkt_type = res[0] & MQTT_PKT_TYPE_MASK


### PR DESCRIPTION
I believe the zero byte check in `_wait_for_msg()` can be removed as the issue was present in 8.x releases while we are now safely into 9.x territory.

Related: #237