### PR TITLE
increase test_recv_timeout delay

### DIFF
--- a/tests/test_recv_timeout.py
+++ b/tests/test_recv_timeout.py
@@ -46,7 +46,7 @@ class RecvTimeout(TestCase):
                     mqtt_client.ping()
 
                 now = time.monotonic()
-                assert recv_timeout <= (now - start) <= (keep_alive + 0.2)
+                assert recv_timeout <= (now - start) <= (keep_alive + 0.5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There's a small interval in `test_recv_timeout.py` of how long to wait for a response. This was first 0.1 seconds, then 0.2, and then that failed too, by a whisker: https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/pull/236#issuecomment-2600877237. This increases the wait to half a second.