### PR TITLE
bump the tolerance for keep alive value in test_recv_timeout.py to 0.3s

### DIFF
--- a/tests/test_recv_timeout.py
+++ b/tests/test_recv_timeout.py
@@ -46,7 +46,7 @@ class RecvTimeout(TestCase):
                     mqtt_client.ping()
 
                 now = time.monotonic()
-                assert recv_timeout <= (now - start) <= (keep_alive + 0.2)
+                assert recv_timeout <= (now - start) <= (keep_alive + 0.3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As discussed in https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/pull/236#issuecomment-2600877237 this raises the tolerance of the keep alive value in the `test_recv_timeout.py` test even further to avoid test failures.