### PR TITLE
Fix missing parameter in MMQTTException

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -1038,7 +1038,7 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
                 if error.errno in (errno.ETIMEDOUT, errno.EAGAIN):
                     # raised by a socket timeout if 0 bytes were present
                     return None
-                raise MMQTTException from error
+                raise MMQTTException("Unexpected error while waiting for messages") from error
 
         if res in [None, b""]:
             # If we get here, it means that there is nothing to be received


### PR DESCRIPTION
This fixes raising a `MMQTTException` with no argument, raising a `TypeError`, when it [requires an `error` argument](https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/blob/6b0f92f8f4a76d8b8431bd21d2656f13dd4b6ed8/adafruit_minimqtt/adafruit_minimqtt.py#L105), as reported in #248 

```
Traceback (most recent call last):
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 1036, in _wait_for_msg
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 1124, in _sock_exact_recv
  File "adafruit_esp32spi/adafruit_esp32spi_socketpool.py", line 171, in recv_into
  File "adafruit_esp32spi/adafruit_esp32spi_socketpool.py", line 198, in _available
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 892, in socket_available
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 431, in _send_command_get_response
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 398, in _wait_response_cmd
  File "adafruit_esp32spi/adafruit_esp32spi.py", line 377, in _wait_spi_char
TimeoutError: Timed out waiting for SPI char

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "code.py", line 247, in <module>
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 1011, in loop
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 1041, in _wait_for_msg
TypeError: function takes 3 positional arguments but 2 were given

Code done running.
```
Notes that: `raise MMQTTException` is equivalent to `raise MMQTTException()`

It should now be (didn't test)
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "code.py", line 247, in <module>
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 1011, in loop
  File "adafruit_minimqtt/adafruit_minimqtt.py", line 1041, in _wait_for_msg
MMQTTException: Unexpected error while waiting for messages

Code done running.
```