### PR TITLE
Enforce size limit in publish()

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -669,7 +669,7 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
                 )
         return rcs
 
-    def publish(  # noqa:  PLR0912, Too many branches
+    def publish(  # noqa:  PLR0912, PLR0915, Too many branches, Too many statements
         self,
         topic: str,
         msg: Union[str, int, float, bytes],
@@ -700,7 +700,11 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
         else:
             raise ValueError("Invalid message data type.")
         if len(msg) > MQTT_MSG_MAX_SZ:
-            raise ValueError(f"Message size larger than {MQTT_MSG_MAX_SZ} bytes.")
+            raise ValueError(f"Message size larger than protocol max {MQTT_MSG_MAX_SZ} bytes.")
+        if len(msg) > self._msg_size_lim:
+            raise ValueError(
+                f"Message size larger than configured limit {self._msg_size_lim} bytes."
+            )
 
         self._valid_qos(qos)
 


### PR DESCRIPTION
Resolves #257

Adds a check and raise against the user configurable `mqtt_msg` property that holds a message size limit.

This change will help the AdafruitIO library have a better error behavior when attempting to publish a message that is too large.

I also think that `mqtt_msg` property name is kind of confusing for the size, but I have left it alone for now since changing would break the API. Though the properties value seemed to have no effect before this change anyhow.