### PR TITLE
feat: Allow arbitrarily short MQTT.loop() timeouts with socket polling

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -53,6 +53,11 @@ from micropython import const
 
 from .matcher import MQTTMatcher
 
+try:
+    import select
+except ImportError:
+    select = None
+
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT.git"
 
@@ -92,6 +97,13 @@ CONNACK_ERRORS = {
 
 _default_sock = None
 _fake_context = None
+
+_SELECT_POLLIN = getattr(select, "POLLIN", 1) if select else 1
+_SELECT_POLL_ERROR_FLAGS = 0
+if select:
+    _SELECT_POLL_ERROR_FLAGS |= getattr(select, "POLLERR", 0)
+    _SELECT_POLL_ERROR_FLAGS |= getattr(select, "POLLHUP", 0)
+    _SELECT_POLL_ERROR_FLAGS |= getattr(select, "POLLNVAL", 0)
 
 
 class MMQTTException(Exception):
@@ -174,6 +186,8 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
         self._socket_pool = socket_pool
         self._ssl_context = ssl_context
         self._sock = None
+        self._socket_poller = None
+        self._poll_socket = None
         self._backwards_compatible_sock = False
         self._use_binary_mode = use_binary_mode
 
@@ -546,6 +560,7 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
         )
         self.session_id = session_id
         self._backwards_compatible_sock = not hasattr(self._sock, "recv_into")
+        self._open_socket_poller()
 
         fixed_header = bytearray([0x10])
 
@@ -611,8 +626,51 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
     def _close_socket(self):
         if self._sock:
             self.logger.debug("Closing socket")
+            self._close_socket_poller()
             self._connection_manager.close_socket(self._sock)
             self._sock = None
+
+    def _open_socket_poller(self) -> None:
+        """Create and register a socket poller, if this socket supports select.poll."""
+        self._socket_poller = None
+        self._poll_socket = None
+        if not select or not hasattr(select, "poll"):
+            return
+
+        try:
+            poller = select.poll()
+            poller.register(self._sock, _SELECT_POLLIN)
+            self._socket_poller = poller
+            # Prefer ipoll when available; real hardware measurements showed near-zero
+            # allocation and faster idle polls.
+            self._poll_socket = getattr(poller, "ipoll", None) or poller.poll
+        except (OSError, TypeError):
+            # This socket cannot be registered with select.poll(); use timeout-based reads.
+            pass
+
+    def _close_socket_poller(self) -> None:
+        """Release socket poll resources."""
+        poller = self._socket_poller
+        self._socket_poller = None
+        self._poll_socket = None
+        if poller is None:
+            return
+
+        poller.unregister(self._sock)
+
+    def _socket_poller_readable(self, timeout_ms: Optional[int]) -> bool:
+        """Return whether the socket poller has a readable socket event."""
+        poll_socket = self._poll_socket
+        if poll_socket is None:
+            raise RuntimeError("Socket poller is unavailable")
+
+        poll_timeout = -1 if timeout_ms is None else max(0, timeout_ms)
+        events = poll_socket(poll_timeout)
+        for event_data in events:
+            event = event_data[1]
+            if event & (_SELECT_POLL_ERROR_FLAGS | _SELECT_POLLIN):
+                return True
+        return False
 
     def _encode_remaining_length(self, fixed_header: bytearray, remaining_length: int) -> None:
         """Encode Remaining Length [2.2.3]"""
@@ -980,23 +1038,31 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
         """Non-blocking message loop. Use this method to check for incoming messages.
         Returns list of packet types of any messages received or None.
 
-        :param float timeout: return after this timeout, in seconds.
+        :param float timeout: return if no message is received before this timeout,
+            in seconds. Reading a message that has begun may take longer.
 
         """
-        if timeout < self._socket_timeout:
-            raise ValueError(
-                f"loop timeout ({timeout}) must be >= "
-                + f"socket timeout ({self._socket_timeout}))"
-            )
+        if timeout < 0:
+            raise ValueError("loop timeout must be >= 0")
 
         self._connected()
         self.logger.debug(f"waiting for messages for {timeout} seconds")
+
+        timeout_ms = int(timeout * 1000)
+        keep_alive_ms = self.keep_alive * 1000
+        socket_timeout_ms = int(self._socket_timeout * 1000)
+        socket_poller = self._socket_poller
+        if socket_poller is None and timeout_ms < socket_timeout_ms:
+            message = f"loop timeout ({timeout}) must be >= socket timeout "
+            message += f"({self._socket_timeout})"
+            message += " without socket readiness support"
+            raise ValueError(message)
 
         stamp = ticks_ms()
         rcs = []
 
         while True:
-            if ticks_diff(ticks_ms(), self._last_msg_sent_timestamp) / 1000 >= self.keep_alive:
+            if ticks_diff(ticks_ms(), self._last_msg_sent_timestamp) >= keep_alive_ms:
                 # Handle KeepAlive by expecting a PINGREQ/PINGRESP from the server
                 self.logger.debug(
                     "KeepAlive period elapsed - requesting a PINGRESP from the server..."
@@ -1004,14 +1070,31 @@ class MQTT:  # noqa: PLR0904  # too-many-public-methods
                 rcs.extend(self.ping())
                 # ping() itself contains a _wait_for_msg() loop which might have taken a while,
                 # so check here as well.
-                if ticks_diff(ticks_ms(), stamp) / 1000 > timeout:
+                if ticks_diff(ticks_ms(), stamp) > timeout_ms:
                     self.logger.debug(f"Loop timed out after {timeout} seconds")
                     break
+
+            loop_timeout_remaining_ms = max(0, timeout_ms - ticks_diff(ticks_ms(), stamp))
+            keep_alive_elapsed_ms = ticks_diff(ticks_ms(), self._last_msg_sent_timestamp)
+            keep_alive_remaining_ms = max(0, keep_alive_ms - keep_alive_elapsed_ms)
+            socket_wait_timeout_ms = min(loop_timeout_remaining_ms, keep_alive_remaining_ms)
+            if socket_poller is not None:
+                socket_readable = self._socket_poller_readable(socket_wait_timeout_ms)
+                if not socket_readable:
+                    if ticks_diff(ticks_ms(), self._last_msg_sent_timestamp) >= keep_alive_ms:
+                        continue
+                    if ticks_diff(ticks_ms(), stamp) >= timeout_ms:
+                        self.logger.debug(f"Loop timed out after {timeout} seconds")
+                        break
+                    continue
+            elif loop_timeout_remaining_ms == 0:
+                self.logger.debug(f"Loop timed out after {timeout} seconds")
+                break
 
             rc = self._wait_for_msg()
             if rc is not None:
                 rcs.append(rc)
-            if ticks_diff(ticks_ms(), stamp) / 1000 > timeout:
+            if ticks_diff(ticks_ms(), stamp) > timeout_ms:
                 self.logger.debug(f"Loop timed out after {timeout} seconds")
                 break
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -15,6 +15,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
+from adafruit_ticks import ticks_add
 
 import adafruit_minimqtt.adafruit_minimqtt as MQTT
 
@@ -102,6 +103,94 @@ class Pingtet:
         raise exc
 
 
+class RecordingPoller:
+    """
+    Poller test double that records registration and ipoll timeout values.
+    """
+
+    def __init__(self, events=None, register_exception=None):
+        self.events = list(events or [])
+        self.registered = []
+        self.unregistered = []
+        self.timeouts = []
+        self.register_exception = register_exception
+
+    def register(self, sock, event_mask):
+        """Record poll registration."""
+        if self.register_exception:
+            raise self.register_exception
+        self.registered.append((sock, event_mask))
+
+    def unregister(self, sock):
+        """Record poll unregistration."""
+        self.unregistered.append(sock)
+
+    def ipoll(self, timeout):
+        """Record timeout and return the next event batch."""
+        self.timeouts.append(timeout)
+        if not self.events:
+            return iter(())
+        return iter(self.events.pop(0))
+
+
+class SelectModuleStub:
+    """
+    Select module stub for socket readiness tests.
+    """
+
+    POLLIN = MQTT._SELECT_POLLIN
+
+    def __init__(self, poller=None):
+        self.poller = poller
+
+    def poll(self):
+        """Return the configured poller."""
+        return self.poller
+
+
+class SelectWithoutPoll:
+    """
+    Select module stub without poll support.
+    """
+
+    POLLIN = 1
+
+
+def make_registered_client(poller):
+    """Create a client with a registered socket poller."""
+    mqtt_client = MQTT.MQTT(
+        broker="127.0.0.1",
+        port=1883,
+        socket_pool=socket,
+        ssl_context=ssl.create_default_context(),
+    )
+    mqtt_client._sock = Nulltet()
+
+    with patch.object(MQTT, "select", SelectModuleStub(poller=poller)):
+        mqtt_client._open_socket_poller()
+
+    return mqtt_client
+
+
+def make_connection_manager(socket):
+    """Create a connection manager mock that returns the given socket."""
+    connection_manager = mock.Mock()
+    connection_manager.get_socket.return_value = socket
+    return connection_manager
+
+
+def patch_successful_connack(mqtt_client):
+    """Patch connect() packet reads to receive a successful CONNACK."""
+    return (
+        patch.object(mqtt_client, "_wait_for_msg", return_value=0x20),
+        patch.object(
+            mqtt_client,
+            "_sock_exact_recv",
+            return_value=bytearray([0x02, 0x00, 0x00]),
+        ),
+    )
+
+
 class TestLoop:
     """basic loop() test"""
 
@@ -115,6 +204,125 @@ class TestLoop:
         retval = self.rcs_val
         self.rcs_val += 1
         return retval
+
+    @pytest.mark.parametrize(
+        "select_module",
+        [
+            None,
+            SelectWithoutPoll(),
+        ],
+        ids=[
+            "no_select",
+            "select_without_poll",
+        ],
+    )
+    def test_open_socket_poller_ignored_without_select_poll(self, select_module):
+        """
+        MiniMQTT should run without select.poll support.
+        """
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+        )
+        mqtt_client._sock = Nulltet()
+
+        with patch.object(MQTT, "select", select_module):
+            mqtt_client._open_socket_poller()
+
+        assert mqtt_client._socket_poller is None
+        assert mqtt_client._poll_socket is None
+
+    def test_connect_creates_socket_poller(self):
+        """
+        Connecting should create a socket poller for the new socket.
+        """
+        sockettet = Nulltet()
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+            socket_timeout=0.25,
+        )
+        connection_manager = make_connection_manager(sockettet)
+        mqtt_client._connection_manager = connection_manager
+        poller = RecordingPoller()
+        connack_header, connack_body = patch_successful_connack(mqtt_client)
+
+        with patch.object(MQTT, "select", SelectModuleStub(poller=poller)):
+            with connack_header, connack_body:
+                assert mqtt_client.connect() == 0
+
+        assert connection_manager.get_socket.call_args.kwargs["timeout"] == 0.25
+        assert mqtt_client._socket_poller is poller
+        assert poller.registered == [(sockettet, MQTT._SELECT_POLLIN)]
+        assert sockettet.sent
+
+    @pytest.mark.parametrize(
+        "register_exception",
+        [
+            OSError("stream operation not supported"),
+            TypeError("fileno() returned a non-integer"),
+        ],
+    )
+    def test_connect_succeeds_with_unpollable_socket(self, register_exception):
+        """
+        A socket can be usable by MiniMQTT even when select.poll cannot register it.
+        """
+        sockettet = Nulltet()
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+        )
+        mqtt_client._connection_manager = make_connection_manager(sockettet)
+        poller = RecordingPoller(register_exception=register_exception)
+        connack_header, connack_body = patch_successful_connack(mqtt_client)
+
+        with patch.object(MQTT, "select", SelectModuleStub(poller=poller)):
+            with connack_header, connack_body:
+                assert mqtt_client.connect() == 0
+
+        assert mqtt_client._socket_poller is None
+        assert sockettet.sent
+
+    @pytest.mark.parametrize(
+        ("events", "timeout", "expected", "expected_timeout"),
+        [
+            ([], 0, False, 0),
+            ([[(object(), 0)]], 0, False, 0),
+            ([[(object(), MQTT._SELECT_POLLIN)]], 250, True, 250),
+            pytest.param(
+                [[(object(), MQTT._SELECT_POLL_ERROR_FLAGS)]],
+                0,
+                True,
+                0,
+                marks=pytest.mark.skipif(
+                    not MQTT._SELECT_POLL_ERROR_FLAGS,
+                    reason="select error flags unavailable on this platform",
+                ),
+                id="error_event",
+            ),
+        ],
+        ids=[
+            "no_events",
+            "non_readable_event",
+            "readable_event",
+            None,
+        ],
+    )
+    def test_socket_poller_readable_events(self, events, timeout, expected, expected_timeout):
+        """
+        Socket polling should classify poll events and pass millisecond timeouts.
+        """
+        poller = RecordingPoller(events=events)
+        mqtt_client = make_registered_client(poller)
+
+        assert mqtt_client._socket_poller_readable(timeout) is expected
+        assert poller.timeouts == [expected_timeout]
 
     def test_loop_basic(self) -> None:
         """
@@ -155,10 +363,94 @@ class TestLoop:
                 assert ret_code == expected_rc
                 expected_rc += 1
 
+    def test_loop_timeout_can_be_less_than_socket_timeout(self):
+        """
+        loop() should allow a timeout smaller than the socket timeout when socket readiness
+        can determine that no message is waiting.
+        """
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+            socket_timeout=1,
+        )
+
+        mqtt_client.is_connected = lambda: True
+        mqtt_client._last_msg_sent_timestamp = MQTT.ticks_ms()
+        socket_readiness = mock.Mock(side_effect=lambda timeout_ms: time.sleep(timeout_ms / 1000))
+        mqtt_client._socket_poller = object()
+        with patch.object(mqtt_client, "_wait_for_msg") as wait_for_msg_mock, patch.object(
+            mqtt_client, "_socket_poller_readable", socket_readiness
+        ):
+            assert mqtt_client.loop(timeout=0.5) is None
+
+        assert socket_readiness.call_args.args[0] == pytest.approx(500, abs=10)
+        wait_for_msg_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        ("last_msg_age_ms", "expected_poll_timeout_ms"),
+        [
+            (9500, 500),
+            (9000, 1000),
+        ],
+        ids=["keepalive_before_loop_timeout", "keepalive_matches_loop_timeout"],
+    )
+    def test_loop_polls_until_keepalive_deadline_before_pinging(
+        self, last_msg_age_ms, expected_poll_timeout_ms
+    ):
+        """
+        Socket readiness waits should stop at the next keepalive deadline and then ping.
+        """
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+            keep_alive=10,
+            socket_timeout=1,
+        )
+        mqtt_client.is_connected = lambda: True
+        mqtt_client._last_msg_sent_timestamp = ticks_add(MQTT.ticks_ms(), -last_msg_age_ms)
+
+        def wait_until_keepalive_deadline(_timeout_ms):
+            mqtt_client._last_msg_sent_timestamp = ticks_add(MQTT.ticks_ms(), -10000)
+            return False
+
+        mqtt_client._socket_poller = object()
+        socket_readiness = mock.Mock(side_effect=wait_until_keepalive_deadline)
+        with patch.object(mqtt_client, "ping", side_effect=RuntimeError), patch.object(
+            mqtt_client, "_socket_poller_readable", socket_readiness
+        ):
+            with pytest.raises(RuntimeError):
+                mqtt_client.loop(timeout=1)
+
+        assert socket_readiness.call_args.args[0] == pytest.approx(expected_poll_timeout_ms, abs=10)
+
     def test_loop_timeout_vs_socket_timeout(self):
         """
-        loop() should throw ValueError if the timeout argument
-        is bigger than the socket timeout.
+        loop() should reject a timeout smaller than the socket timeout when socket readiness
+        is unavailable.
+        """
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+            socket_timeout=1,
+        )
+
+        mqtt_client.is_connected = lambda: True
+        mqtt_client._last_msg_sent_timestamp = MQTT.ticks_ms()
+        mqtt_client._socket_poller = None
+        with pytest.raises(ValueError) as context:
+            mqtt_client.loop(timeout=0.5)
+
+        assert "socket readiness support" in str(context)
+
+    def test_loop_rejects_negative_timeout(self):
+        """
+        loop() should reject negative timeout values.
         """
         mqtt_client = MQTT.MQTT(
             broker="127.0.0.1",
@@ -170,9 +462,33 @@ class TestLoop:
 
         mqtt_client.is_connected = lambda: True
         with pytest.raises(ValueError) as context:
-            mqtt_client.loop(timeout=0.5)
+            mqtt_client.loop(timeout=-0.1)
 
         assert "loop timeout" in str(context)
+
+    def test_loop_zero_timeout_processes_waiting_message(self):
+        """
+        loop() should process an already-waiting message when timeout is zero.
+        """
+        mqtt_client = MQTT.MQTT(
+            broker="127.0.0.1",
+            port=1883,
+            socket_pool=socket,
+            ssl_context=ssl.create_default_context(),
+            socket_timeout=1,
+        )
+
+        mqtt_client.is_connected = lambda: True
+        mqtt_client._last_msg_sent_timestamp = MQTT.ticks_ms()
+        mqtt_client._socket_poller = object()
+        socket_readiness = mock.Mock(side_effect=[True, False])
+        with patch.object(mqtt_client, "_wait_for_msg") as wait_for_msg_mock, patch.object(
+            mqtt_client, "_socket_poller_readable", socket_readiness
+        ):
+            wait_for_msg_mock.return_value = MQTT.MQTT_PUBLISH
+            assert mqtt_client.loop(timeout=0) == [MQTT.MQTT_PUBLISH]
+
+        wait_for_msg_mock.assert_called_once()
 
     def test_loop_is_connected(self):
         """
@@ -210,6 +526,9 @@ class TestLoop:
         mqtt_client.is_connected = lambda: True
         mocket = Pingtet()
         mqtt_client._sock = mocket
+        mqtt_client._last_msg_sent_timestamp = ticks_add(
+            MQTT.ticks_ms(), -keep_alive_timeout * 1000
+        )
 
         start = time.monotonic()
         res = mqtt_client.loop(timeout=2 * keep_alive_timeout + recv_timeout)

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -7,6 +7,7 @@
 import logging
 import ssl
 import sys
+from unittest import mock
 
 import pytest
 from mocket import Mocket
@@ -30,6 +31,7 @@ class FakeConnectionManager:
     def __init__(self, socket):
         self._socket = socket
         self.close_cnt = 0
+        self.closed_sockets = []
 
     def get_socket(  # noqa: PLR0913, Too many arguments
         self,
@@ -49,6 +51,7 @@ class FakeConnectionManager:
 
     def close_socket(self, socket) -> None:
         self.close_cnt += 1
+        self.closed_sockets.append(socket)
 
 
 def handle_subscribe(client, user_data, topic, qos):
@@ -184,6 +187,9 @@ def test_reconnect(topics, to_send) -> None:
     mocket = Mocket(to_send)
     mqtt_client._connection_manager = FakeConnectionManager(mocket)
     mqtt_client.connect()
+    poller = mock.Mock()
+    mqtt_client._socket_poller = poller
+    mqtt_client._poll_socket = mock.Mock()
 
     mqtt_client.logger = logger
 
@@ -198,6 +204,10 @@ def test_reconnect(topics, to_send) -> None:
 
     assert user_data.get("disconnect") == True
     assert mqtt_client._connection_manager.close_cnt == 1
+    assert mqtt_client._connection_manager.closed_sockets == [mocket]
+    poller.unregister.assert_called_once_with(mocket)
+    assert mqtt_client._socket_poller is None
+    assert mqtt_client._poll_socket is None
     assert set(user_data.get("topics")) == set([t[0] for t in topics])
 
 


### PR DESCRIPTION
### Why
`MQTT.loop()` currently requires`timeout >= socket_timeout`. For sensor apps this can delay publishing: if a sensor event happens while the app is waiting in `MQTT.loop()`, the app cannot publish until that wait returns. Lowering the global `socket_timeout` only partly helps, because broker connections can then warn when they take longer than the socket timeout to set up.

Ideally `MQTT.loop()` should be able to check quickly, including with no wait, without changing the socket timeout used by other network operations.

Directly addresses #241, #195, and the short-loop-timeout/socket-timeout subcase in #148.

### How
We register connected sockets with `select.poll()` when available. `MQTT.loop()` uses readiness polling before reading from the socket, and each poll wait is capped at the earlier of the remaining loop timeout or the next keepalive deadline.

The existing implementation is still used when polling is unavailable depending on the device.

In terms of edge cases, negative loop timeouts are rejected, pollers are cleaned up when sockets close, and poll error events are treated as readable so normal socket handling reports the error.

### Test Plan
- `python -m pytest tests/test_loop.py tests/test_reconnect.py`
- `python -m tox -e lint -- --all-files`

I ran hardware tests and polling benchmarks on a Raspberry Pi Pico 2 W with CircuitPython 10.2.1. The board supports `select.poll()` and `poller.ipoll()`. Idle polling returned no events as expected. `ipoll()` was a little faster than `poll()`, used almost no extra heap in the allocation check (this was empirical motivation to support `ipoll` in this PR), and worked in paced 100 Hz and 1000 Hz loops without adding missed periods beyond the baseline.